### PR TITLE
Add strict min version and extension id and bump version to 4.0.2. Fi…

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -12,7 +12,7 @@
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!--Firefox-->
-        <em:minVersion>51.0a1</em:minVersion>
+        <em:minVersion>53.0</em:minVersion>
         <em:maxVersion>*</em:maxVersion>
       </Description>
     </em:targetApplication>

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "Multi-Account Containers",
+  "name": "Firefox Multi-Account Containers",
   "version": "4.0.2",
 
   "description": "Multi-Account Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
@@ -11,7 +11,8 @@
 
   "applications": {
     "gecko": {
-      "strict_min_version": "51.0",
+      "id": "@testpilot-containers",
+      "strict_min_version": "53.0",
       "update_url": "https://testpilot.firefox.com/files/@testpilot-containers/updates.json"
     }
   },


### PR DESCRIPTION
…xes #692 

@groovecoder I'm hoping that adding the addon id will fix windows in Nightly which doesn't seem to install the browser action, however we might also think this is sandboxing.

Could you double check the upgrade process on Mac (I'm always nervous of changes like this)?

The min version is to address #692 