### PR TITLE
bump version to 4.0.3

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -16,7 +16,7 @@
         <em:maxVersion>*</em:maxVersion>
       </Description>
     </em:targetApplication>
-    <em:version>4.0.2</em:version>
+    <em:version>4.0.3</em:version>
     <em:unpack>false</em:unpack>
   </Description>
 </RDF>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testpilot-containers",
   "title": "Multi-Account Containers",
   "description": "Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "author": "Andrea Marchesini, Luke Crouch and Jonathan Kingston",
   "bugs": {
     "url": "https://github.com/mozilla/testpilot-containers/issues"

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Multi-Account Containers",
-  "version": "4.0.2",
+  "version": "4.0.3",
 
   "description": "Multi-Account Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
   "icons": {


### PR DESCRIPTION
New version to release these bug-fixes:

c433c6b Clean up disabled Private Mode notice. Fixes #878
1c09c29 Fix assignment of stale containers. Fixes #803 Fixes #827
07711aa Preventing default on enter handler as it seems to call click handlers now. Fixes #856
16ed899 Change delete title to remove. Fixes #700
88e6dc7 Add strict min version and extension id and bump version to 4.0.2. Fixes #692. Fixes #852
77ba1b7 Store only one of the current version opened. Fixes #833
e84e482 Minor README edit
3ec81e3 Add launch notice in README
01a6288 Fix dumping UUID image into the page. Fixes #812