### PR TITLE
Add delete numbered containers button

### DIFF
--- a/webextension/css/popup.css
+++ b/webextension/css/popup.css
@@ -467,6 +467,24 @@ manage things like container crud */
   background: #f2f2f2;
 }
 
+#edit-containers-panel #delete-numbered-link {
+  align-items: center;
+  block-size: var(--block-url-label-size);
+  border: 1px solid #d8d8d8;
+  border-radius: var(--small-radius);
+  color: var(--title-text-color);
+  display: flex;
+  font-size: var(--small-text-size);
+  inline-size: var(--inline-button-size);
+  justify-content: center;
+  text-decoration: none;
+}
+
+#edit-containers-panel #delete-numbered-link:hover,
+#edit-containers-panel #delete-numbered-link:focus {
+  background: #f2f2f2;
+}
+
 span ~ .panel-header-text {
   padding-block-end: 0;
   padding-block-start: 0;

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -840,6 +840,21 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       Logic.showPreviousPanel();
     });
 
+    Logic.addEnterHandler(document.querySelector("#delete-numbered-link"), async function () {
+      try {
+        const promises = Logic.identities().map(identity => {
+          if (identity.name.match(/^Container #\d+$/)) {
+            return Logic.removeIdentity(Logic.userContextId(identity.cookieStoreId));
+          }
+        });
+        await Promise.all(promises);
+        await Logic.refreshIdentities();
+        Logic.showPreviousPanel();
+      } catch (e) {
+        Logic.showPanel(P_CONTAINERS_LIST);
+      }
+    });
+
     this._editForm = document.getElementById("edit-container-panel-form");
     const editLink = document.querySelector("#edit-container-ok-link");
     Logic.addEnterHandler(editLink, () => {

--- a/webextension/popup.html
+++ b/webextension/popup.html
@@ -126,6 +126,9 @@
     <div class="panel-header">
       <h3 class="panel-header-text">Edit Containers</h3>
     </div>
+    <div class="container-panel-controls">
+      <a href="#" class="action-link" id="delete-numbered-link" title="Delete numbered containers">Delete #</a>
+    </div>
     <div class="scrollable panel-content">
       <table class="unstriped">
         <tbody id="edit-identities-list"></tbody>


### PR DESCRIPTION
Containers are pretty good for web development because they're more permanent than private windows and less permanent than not private windows. I often end up with a bunch of containers that I use to test some feature and never use again. It's a pain to delete them one by one. This is an attempt at addressing this issue. I realise it's not useful for the average Firefox user though. Comments?