### PR TITLE
Add shortcuts for hiding and showing container groups

### DIFF
--- a/webextension/css/popup.css
+++ b/webextension/css/popup.css
@@ -450,7 +450,7 @@ manage things like container crud */
   margin-inline-start: var(--inline-item-space-size);
 }
 
-#container-panel #sort-containers-link {
+#container-panel .action-link {
   align-items: center;
   block-size: var(--block-url-label-size);
   border: 1px solid #d8d8d8;
@@ -460,11 +460,12 @@ manage things like container crud */
   font-size: var(--small-text-size);
   inline-size: var(--inline-button-size);
   justify-content: center;
+  margin-left: var(--block-line-space-size);
   text-decoration: none;
 }
 
-#container-panel #sort-containers-link:hover,
-#container-panel #sort-containers-link:focus {
+#container-panel .action-link:hover,
+#container-panel .action-link:focus {
   background: #f2f2f2;
 }
 

--- a/webextension/js/background/messageHandler.js
+++ b/webextension/js/background/messageHandler.js
@@ -68,6 +68,9 @@ const messageHandler = {
       case "exemptContainerAssignment":
         response = assignManager._exemptTab(m);
         break;
+      case "unhideAllTabs":
+        response = backgroundLogic.unhideAllTabs(m.message.windowId);
+        break;
       }
       return response;
     });

--- a/webextension/js/background/messageHandler.js
+++ b/webextension/js/background/messageHandler.js
@@ -71,6 +71,12 @@ const messageHandler = {
       case "unhideAllTabs":
         response = backgroundLogic.unhideAllTabs(m.message.windowId);
         break;
+      case "showOnly":
+        response = backgroundLogic.showOnly({
+          windowId: m.windowId,
+          cookieStoreId: m.cookieStoreId
+        });
+        break;
       }
       return response;
     });

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -500,6 +500,20 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       }
     });
 
+    Logic.addEnterHandler(document.querySelector("#unhide-all-containers-link"), async function () {
+      try {
+        await browser.runtime.sendMessage({
+          method: "unhideAllTabs",
+          message: {
+            windowId: browser.windows.WINDOW_ID_CURRENT
+          }
+        });
+        window.close();
+      } catch (e) {
+        window.close();
+      }
+    });
+
     document.addEventListener("keydown", (e) => {
       const selectables = [...document.querySelectorAll("[tabindex='0'], [tabindex='-1']")];
       const element = document.activeElement;

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -719,6 +719,19 @@ Logic.registerPanel(P_CONTAINER_INFO, {
       }
     });
 
+    Logic.addEnterHandler(document.querySelector("#container-info-hideothers"), async function () {
+      try {
+        browser.runtime.sendMessage({
+          method: "showOnly",
+          windowId: browser.windows.WINDOW_ID_CURRENT,
+          cookieStoreId: Logic.currentCookieStoreId()
+        });
+        window.close();
+      } catch (e) {
+        window.close();
+      }
+    });
+
     // Check if the user has incompatible add-ons installed
     try {
       const incompatible = await browser.runtime.sendMessage({
@@ -774,6 +787,9 @@ Logic.registerPanel(P_CONTAINER_INFO, {
 
     const hideShowLabel = document.getElementById("container-info-hideorshow-label");
     hideShowLabel.textContent = identity.hasHiddenTabs ? "Show this container" : "Hide this container";
+
+    const hideOthersLabel = document.getElementById("container-info-hideothers");
+    hideOthersLabel.textContent = identity.hasHiddenTabs ? "Show only this container" : "Hide other containers";
 
     // Let's remove all the previous tabs.
     const table = document.getElementById("container-info-table");

--- a/webextension/popup.html
+++ b/webextension/popup.html
@@ -108,6 +108,7 @@
       </label>
     </div>
     <div class="container-panel-controls">
+      <a href="#" class="action-link" id="unhide-all-containers-link" title="Show all hidden containers">Show all</a>
       <a href="#" class="action-link" id="sort-containers-link" title="Sort tabs into container order">Sort Tabs</a>
     </div>
     <div class="scrollable panel-content" tabindex="-1">

--- a/webextension/popup.html
+++ b/webextension/popup.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
@@ -141,6 +142,7 @@
           <img id="container-info-hideorshow-icon" alt="Hide Container icon" src="/img/container-hide.svg" class="icon container-info-panel-hideorshow-icon"/>
           <span id="container-info-hideorshow-label">Hide this container</span>
         </div>
+        <div class="select-row clickable container-info-panel-hide-others container-info-has-tabs" id="container-info-hideothers">Hide other containers</div>
         <div class="select-row clickable container-info-panel-movetabs container-info-has-tabs" id="container-info-movetabs">Move tabs to a new window</div>
         <div class="scrollable">
           <table id="container-info-table" class="container-info-list">


### PR DESCRIPTION
This PR adds the following features:

- Icon buttons to toggle a container's visibility from the container overview popup
- A button to unhide all containers, next to the "Sort tabs" button on the popup
- A button to show only tabs from a container on the container info pane of the popup

This is my first work with web extensions, and I'm open to suggestions for improvements and the like.
If this would be better as three different PRs, I would be happy to split it up.