### PR TITLE
[WIP] Add key combination to open new tab in the same container.

### DIFF
--- a/webextension/js/background/assignManager.js
+++ b/webextension/js/background/assignManager.js
@@ -177,6 +177,20 @@ const assignManager = {
     browser.webRequest.onBeforeRequest.addListener((options) => {
       return this.onBeforeRequest(options);
     },{urls: ["<all_urls>"], types: ["main_frame"]}, ["blocking"]);
+
+    browser.commands.onCommand.addListener(command => {
+      return this._onCommandHandler(command);
+    });
+  },
+
+  async _onCommandHandler(command) {
+    if (command === "new-tab-container") {
+      return browser.tabs.query({active: true, lastFocusedWindow: true}).then(tabs => {
+        return tabs[0];
+      }).then(tab => {
+        return browser.tabs.create({cookieStoreId: tab.cookieStoreId});
+      });
+    }
   },
 
   async _onClickedHandler(info, tab) {

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -38,6 +38,12 @@
         "mac": "MacCtrl+Period"
       },
       "description": "Open containers panel"
+    },
+    "new-tab-container": {
+      "suggested_key": {
+        "default": "Ctrl+Y"
+      },
+      "description": "Open new tab with the same container"
     }
   },
 


### PR DESCRIPTION
I was let down that this addon contains no functionality to make Ctrl+T and Ctrl+Alt+Enter open the new tab in the same container. See issue #462.

I found that this is also tracked in [Bugzilla Bug 1406371](https://bugzilla.mozilla.org/show_bug.cgi?id=1406371).

This PR adds the key combination Ctrl+Y as a workaround until this is implemented in Firefox.

This is still [WIP], as the command is not called when the keys are pressed unless you have the popup open, for some reason. Did I place the command handler in the wrong place?