### PR TITLE
Make it possible to reopen current tab in other container #942

### DIFF
--- a/webextension/css/popup.css
+++ b/webextension/css/popup.css
@@ -514,8 +514,21 @@ span ~ .panel-header-text {
 }
 
 #current-tab > label {
-  display: contents;
   font-size: var(--small-text-size);
+  grid-column: 2 / 4;
+  grid-column-start: 2;
+}
+
+#current-tab select {
+  color: var(--text-normal-color);
+  font-size: var(--small-text-size);
+  inline-size: var(--inline-button-size);
+  justify-content: center;
+  text-decoration: none;
+}
+
+#current-tab > label[for="container-page-assigned"] {
+  display: contents;
 }
 
 #current-tab > label > input {

--- a/webextension/popup.html
+++ b/webextension/popup.html
@@ -99,6 +99,11 @@
     <div id="current-tab">
       <h3>Current Tab</h3>
       <div id="current-page"></div>
+      <label for="container-page-reopen">
+        <span>Reopen tab in</span>
+        <select id="container-page-reopen">
+        </select>
+      </label>
       <label for="container-page-assigned">
         <input type="checkbox" id="container-page-assigned" />
         <span class="truncate-text">


### PR DESCRIPTION
Fixes #942. Implements @ChenMorpheus' design, though not fully.
Misses styling. Both in terms of of the drop down looks, and that the identities doesn't have colors and icons.

I do not have the css experience to style the drop-down menu of the select form. Just styling the form border proved difficult as I had to remove default behaviour, and then had problems reimplementing hover style. I found no way to display images in the dropdown either.