### PR TITLE
Adds shortcut to open containers.

### DIFF
--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -516,12 +516,48 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
           previousElement.focus();
         }
       }
+      function select(num) {
+        const element = selectables[num];
+        if (element) {
+          element.click();
+        }
+      }
       switch (e.keyCode) {
       case 40:
         next();
         break;
       case 38:
         previous();
+        break;
+      case 49:
+        select(1);
+        break;
+      case 50:
+        select(2);
+        break;
+      case 51:
+        select(3);
+        break;
+      case 52:
+        select(4);
+        break;
+      case 53:
+        select(5);
+        break;
+      case 53:
+        select(6);
+        break;
+      case 53:
+        select(7);
+        break;
+      case 53:
+        select(8);
+        break;
+      case 53:
+        select(99);
+        break;
+      case 48:
+        select(10);
         break;
       }
     });

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -529,35 +529,13 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       case 38:
         previous();
         break;
-      case 49:
-        select(1);
-        break;
-      case 50:
-        select(2);
-        break;
-      case 51:
-        select(3);
-        break;
-      case 52:
-        select(4);
-        break;
-      case 53:
-        select(5);
-        break;
-      case 54:
-        select(6);
-        break;
-      case 55:
-        select(7);
-        break;
-      case 56:
-        select(8);
-        break;
-      case 57:
-        select(9);
-        break;
       case 48:
         select(10);
+        break;
+      default:
+        if (e.keyCode >= 49 && e.keyCode <= 57) {
+          select(e.keyCode - 48);
+        }
         break;
       }
     });

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -544,17 +544,17 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       case 53:
         select(5);
         break;
-      case 53:
+      case 54:
         select(6);
         break;
-      case 53:
+      case 55:
         select(7);
         break;
-      case 53:
+      case 56:
         select(8);
         break;
-      case 53:
-        select(99);
+      case 57:
+        select(9);
         break;
       case 48:
         select(10);

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -516,12 +516,6 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
           previousElement.focus();
         }
       }
-      function select(num) {
-        const element = selectables[num];
-        if (element) {
-          element.click();
-        }
-      }
       switch (e.keyCode) {
       case 40:
         next();
@@ -529,12 +523,12 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       case 38:
         previous();
         break;
-      case 48:
-        select(10);
-        break;
       default:
         if (e.keyCode >= 49 && e.keyCode <= 57) {
-          select(e.keyCode - 48);
+          const element = selectables[e.keyCode - 48];
+          if (element) {
+            element.click();
+          }
         }
         break;
       }


### PR DESCRIPTION
Makes it more effective to open the first ten containers in the
containers list. Keys 1-0 will open containers 1-10, if that container
exists.

Note: the plugin's popup panel does not autofocus when opened. This
requires the user to focus on the panel by either clicking or pressing
TAB before using shortcut keys. This behavior is consistent with the previous shortcuts for
this addon.