### PR TITLE
id:@testpilot-containers to manifest.json; 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testpilot-containers",
   "title": "Multi-Account Containers",
   "description": "Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "Andrea Marchesini, Luke Crouch and Jonathan Kingston",
   "bugs": {
     "url": "https://github.com/mozilla/testpilot-containers/issues"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Multi-Account Containers",
-  "version": "5.0.0",
+  "version": "5.0.1",
 
   "description": "Multi-Account Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
   "icons": {
@@ -11,6 +11,7 @@
 
   "applications": {
     "gecko": {
+      "id": "@testpilot-containers",
       "strict_min_version": "57.0"
     }
   },


### PR DESCRIPTION
`manifest.json` needs `id: @testpilot-containers` to make sure it updates the existing 4.x legacy add-on instead of making a new one.