### PR TITLE
Fix #1053.

### DIFF
--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -131,9 +131,13 @@ const backgroundLogic = {
     let newWindowObj;
     let hiddenDefaultTabToClose;
     if (list.length) {
-      newWindowObj = await browser.windows.create({
-        tabId: list.shift().id
-      });
+      newWindowObj = await browser.windows.create();
+
+      // Pin the default tab in the new window so existing pinned tabs can be moved after it.
+      // From the docs (https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/move):
+      //   Note that you can't move pinned tabs to a position after any unpinned tabs in a window, or move any unpinned tabs to a position before any pinned tabs.
+      await browser.tabs.update(newWindowObj.tabs[0].id, { pinned: true });
+
       browser.tabs.move(list.map((tab) => tab.id), {
         windowId: newWindowObj.id,
         index: -1


### PR DESCRIPTION
Create the new window with the default tab rather than an existing tab,
then pin the default tab. This allows any pinned tabs to be moved to the
new window because they're not allowed to be moved after a un-pinned
tab. The default tab is automatically closed later in `moveTabsToWindow`
because it's not a part of the container.