### PR TITLE
Pass opener tab id when creating tabs in order to know the parent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ README.html
 addon.env
 
 src/web-ext-artifacts/*
+
+# JetBrains IDE files
+.idea

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -143,7 +143,10 @@ const assignManager = {
         || this.storageArea.isExempted(options.url, tab.id)) {
       return {};
     }
-
+    const removeTab = backgroundLogic.NEW_TAB_PAGES.has(tab.url)
+      || (messageHandler.lastCreatedTab
+        && messageHandler.lastCreatedTab.id === tab.id);
+    const openTabId = removeTab ? tab.openerTabId : tab.id;
     this.reloadPageInContainer(
         options.url,
         userContextId,
@@ -151,7 +154,7 @@ const assignManager = {
         tab.index + 1,
         tab.active,
         siteSettings.neverAsk,
-        tab.id
+        openTabId
         );
     this.calculateContextMenu(tab);
 
@@ -166,9 +169,7 @@ const assignManager = {
             however they don't run on about:blank so this would likely be just as hacky.
         We capture the time the tab was created and close if it was within the timeout to try to capture pages which haven't had user interaction or history.
     */
-    if (backgroundLogic.NEW_TAB_PAGES.has(tab.url)
-        || (messageHandler.lastCreatedTab
-        && messageHandler.lastCreatedTab.id === tab.id)) {
+    if (removeTab) {
       browser.tabs.remove(tab.id);
     }
     return {

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -144,7 +144,15 @@ const assignManager = {
       return {};
     }
 
-    this.reloadPageInContainer(options.url, userContextId, siteSettings.userContextId, tab.index + 1, tab.active, siteSettings.neverAsk);
+    this.reloadPageInContainer(
+        options.url,
+        userContextId,
+        siteSettings.userContextId,
+        tab.index + 1,
+        tab.active,
+        siteSettings.neverAsk,
+        tab.id
+        );
     this.calculateContextMenu(tab);
 
     /* Removal of existing tabs:
@@ -350,13 +358,13 @@ const assignManager = {
     });
   },
 
-  reloadPageInContainer(url, currentUserContextId, userContextId, index, active, neverAsk = false) {
+  reloadPageInContainer(url, currentUserContextId, userContextId, index, active, neverAsk = false, openerTabId = null) {
     const cookieStoreId = backgroundLogic.cookieStoreId(userContextId);
     const loadPage = browser.extension.getURL("confirm-page.html");
     // False represents assignment is not permitted
     // If the user has explicitly checked "Never Ask Again" on the warning page we will send them straight there
     if (neverAsk) {
-      browser.tabs.create({url, cookieStoreId, index, active});
+      browser.tabs.create({url, cookieStoreId, index, active, openerTabId});
     } else {
       let confirmUrl = `${loadPage}?url=${this.encodeURLProperty(url)}&cookieStoreId=${cookieStoreId}`;
       let currentCookieStoreId;
@@ -367,6 +375,7 @@ const assignManager = {
       browser.tabs.create({
         url: confirmUrl,
         cookieStoreId: currentCookieStoreId,
+        openerTabId,
         index,
         active
       }).then(() => {


### PR DESCRIPTION
When reloading a tab in a container, we will now pass the openerTabId. This is primarly for https://github.com/piroor/treestyletab but also to pass more complete information when creating tabs.

Related to #1065   feature request] pass opener tab id when creating tabs in order to know the parent