### PR TITLE
Allow webextensions with contextualIdentities permission to get assignments

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,6 +26,7 @@
     "contextualIdentities",
     "history",
     "idle",
+    "management",
     "storage",
     "tabs",
     "webRequestBlocking",


### PR DESCRIPTION
Hi,

thanks for your work on Multi-Account Containers!

I've developed an "[extra Add-on](https://github.com/mozilla/multi-account-containers/issues/929)" named Temporary Containers ([AMO](https://addons.mozilla.org/en-US/firefox/addon/temporary-containers) / [GitHub](https://github.com/stoically/firefox-add-on-temporary-containers)) and in order to support some of the available features (e.g. automatically open clicked links in a Temporary Container) I have to rely on fuzzy logic to make a best guess about when MAC is going to reopen an URL in a Container or Confirm Page. This leads to random bugs where Tabs get closed or multiple Tabs get opened - up to the point that people [decide against using my Add-on](https://github.com/stoically/firefox-add-on-temporary-containers/issues/15#issuecomment-360484034).

If there's a chance that this PR can get merged I could reduce the number of possible problems when MAC and my Add-on get used in combination.

Please let me know if there's anything I can do to make a merge more likely.

Usage example from a whitelisted extension:
```js
const assignment = await browser.runtime.sendMessage('@testpilot-containers', {
  method: 'getAssignment',
  url: 'http://example.com'
});
```
Best regards