### PR TITLE
Add and fix tests for 6.0.0

### DIFF
--- a/test/browser.mock.js
+++ b/test/browser.mock.js
@@ -8,6 +8,9 @@ module.exports = () => {
       onMessage: {
         addListener: sinon.stub(),
       },
+      onMessageExternal: {
+        addListener: sinon.stub(),
+      },
       sendMessage: sinon.stub().resolves(),
     },
     webRequest: {
@@ -64,6 +67,15 @@ module.exports = () => {
     browserAction: {
       setBadgeBackgroundColor: sinon.stub(),
       setBadgeText: sinon.stub()
+    },
+    management: {
+      get: sinon.stub(),
+      onInstalled: {
+        addListener: sinon.stub()
+      },
+      onUninstalled: {
+        addListener: sinon.stub()
+      }
     },
     extension: {
       getURL: sinon.stub().returns("moz-extension://multi-account-containers/confirm-page.html")

--- a/test/features/assignment.test.js
+++ b/test/features/assignment.test.js
@@ -35,6 +35,7 @@ describe("Assignment Feature", () => {
                `url=${encodeURIComponent(activeTab.url)}` +
                `&cookieStoreId=${activeTab.cookieStoreId}`,
           cookieStoreId: undefined,
+          openerTabId: null,
           index: 2,
           active: true
         });

--- a/test/features/external-webextensions.test.js
+++ b/test/features/external-webextensions.test.js
@@ -1,0 +1,67 @@
+describe("External Webextensions", () => {
+  const activeTab = {
+    id: 1,
+    cookieStoreId: "firefox-container-1",
+    url: "http://example.com",
+    index: 0
+  };
+  beforeEach(async () => {
+    await helper.browser.initializeWithTab(activeTab);
+    await helper.popup.clickElementById("container-page-assigned");
+  });
+
+  describe("with contextualIdentities permissions", () => {
+    it("should be able to get assignments", async () => {
+      background.browser.management.get.resolves({
+        permissions: ["contextualIdentities"]
+      });
+
+      const message = {
+        method: "getAssignment",
+        url: "http://example.com"
+      };
+      const sender = {
+        id: "external-webextension"
+      };
+
+      // currently not possible to get the return value of yielding with sinon
+      // so we expect that if no error is thrown and the storage was called, everything is ok
+      // maybe i get around to provide a PR https://github.com/sinonjs/sinon/issues/903
+      //
+      // the alternative would be to expose the actual messageHandler and call it directly
+      // but personally i think that goes against the black-box-ish nature of these feature tests
+      const rejectionStub = sinon.stub();
+      process.on("unhandledRejection", rejectionStub);
+      background.browser.runtime.onMessageExternal.addListener.yield(message, sender);
+      await nextTick();
+      process.removeListener("unhandledRejection", rejectionStub);
+      rejectionStub.should.not.have.been.called;
+      background.browser.storage.local.get.should.have.been.called;
+    });
+  });
+
+  describe("without contextualIdentities permissions", () => {
+    it("should throw an error", async () => {
+      background.browser.management.get.resolves({
+        permissions: []
+      });
+
+      const message = {
+        method: "getAssignment",
+        url: "http://example.com"
+      };
+      const sender = {
+        id: "external-webextension"
+      };
+
+      const rejectionStub = sinon.spy();
+      process.on("unhandledRejection", rejectionStub);
+      background.browser.runtime.onMessageExternal.addListener.yield(message, sender);
+      await nextTick();
+      process.removeListener("unhandledRejection", rejectionStub);
+      rejectionStub.should.have.been.calledWith(sinon.match({
+        message: "Missing contextualIdentities permission"
+      }));
+    });
+  });
+});


### PR DESCRIPTION
Thanks for merging the other PRs!

Here's a fix for the assignment feature test to cover the new openerTabId that gets passed in and a feature test for the external webextensions messaging.