### PR TITLE
Option to not show hidden tabs when opening a new tab in a hidden container

### DIFF
--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -119,8 +119,8 @@ const messageHandler = {
           // increment the counter of container tabs opened
           this.incrementCountOfContainerTabsOpened();
         }
-
-        this.unhideContainer(tab.cookieStoreId);
+        // Optionally open hidden tabs.
+        this.optionallyUnhideContainer(tab.cookieStoreId);
       }
       setTimeout(() => {
         this.lastCreatedTab = null;
@@ -143,6 +143,15 @@ const messageHandler = {
       browser.storage.local.set({achievements});
       browser.browserAction.setBadgeBackgroundColor({color: "rgba(0,217,0,255)"});
       browser.browserAction.setBadgeText({text: "NEW"});
+    }
+  },
+
+  async optionallyUnhideContainer(cookieStoreId) {
+    const key = "showAllTabs";
+    // Use true if not set in the storage yet. Will show all hidden tabs as default.
+    const showAllTabs = await browser.storage.local.get({[key]: true});
+    if (showAllTabs.showAllTabs) {
+      this.unhideContainer(cookieStoreId);
     }
   },
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -62,6 +62,10 @@
     }
   ],
 
+  "options_ui": {
+    "page": "options/options.html"
+  },
+	      
   "web_accessible_resources": [
     "/img/container-site-d-24.png"
   ]

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+
+  <body>
+
+    <form>
+      <label>Show hidden tabs when a new tab is opened in a hidden container <input type="checkbox" id="showAllTabs" ></label>
+      <button type="submit">Save</button>
+    </form>
+
+    <script src="options.js"></script>
+
+  </body>
+
+</html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,0 +1,24 @@
+function saveOptions(e) {
+  e.preventDefault();
+  browser.storage.local.set({
+    showAllTabs : document.querySelector("#showAllTabs").checked 
+  });
+}
+
+function restoreOptions() {
+
+  function setShowAllTabs(result) {
+    document.querySelector("#showAllTabs").checked = result.showAllTabs;
+  }
+
+  function onError(error) {
+    console.log(`Error: ${error}`);
+  }
+  var key = "showAllTabs";
+  var showAllTabs = browser.storage.local.get({[key]: true});
+  showAllTabs.then(setShowAllTabs, onError);
+}
+
+document.addEventListener("DOMContentLoaded", restoreOptions);
+document.querySelector("form").addEventListener("submit", saveOptions);
+


### PR DESCRIPTION
I have added an option to not show all tabs in a hidden container when opening a new tab in the same container. Also prevents duplicate tabs when moving a hidden container to a new window.

Mitigates:
https://github.com/mozilla/multi-account-containers/issues/791
https://github.com/mozilla/multi-account-containers/issues/795

I have used this for some time without problems.

Any comment is most welcome!