### PR TITLE
Cancel redirects for the same requestIds and urls if originating from the same tabId

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "json": "^9.0.6",
     "mocha": "^5.0.0",
     "npm-run-all": "^4.0.0",
-    "sinon": "^4.2.2",
+    "sinon": "^4.4.0",
     "sinon-chai": "^2.14.0",
     "stylelint": "^7.9.0",
     "stylelint-config-standard": "^16.0.0",

--- a/test/browser.mock.js
+++ b/test/browser.mock.js
@@ -19,6 +19,9 @@ module.exports = () => {
       },
       onCompleted: {
         addListener: sinon.stub()
+      },
+      onErrorOccurred: {
+        addListener: sinon.stub()
       }
     },
     windows: {

--- a/test/helper.js
+++ b/test/helper.js
@@ -18,19 +18,21 @@ module.exports = {
       });
     },
 
-    async openNewTab(tab, options = {isAsync: true}) {
+    async openNewTab(tab, options = {}) {
+      if (options.resetHistory) {
+        background.browser.tabs.create.resetHistory();
+        background.browser.tabs.remove.resetHistory();
+      }
       background.browser.tabs.get.resolves(tab);
-      background.browser.webRequest.onBeforeRequest.addListener.yield({
+      background.browser.tabs.onCreated.addListener.yield(tab);
+      const [promise] = background.browser.webRequest.onBeforeRequest.addListener.yield({
         frameId: 0,
         tabId: tab.id,
         url: tab.url,
         requestId: options.requestId
       });
-      background.browser.tabs.onCreated.addListener.yield(tab);
-      if (!options.isAsync) {
-        return;
-      }
-      await nextTick();
+
+      return promise;
     }
   },
 

--- a/test/issues/940.test.js
+++ b/test/issues/940.test.js
@@ -22,8 +22,7 @@ describe("#940", () => {
         active: true
       };
       helper.browser.openNewTab(newTab, {
-        requestId: 1,
-        isAsync: false
+        requestId: 1
       });
 
       // other addon sees the same request
@@ -38,6 +37,144 @@ describe("#940", () => {
       await nextTick();
 
       background.browser.tabs.create.should.have.been.calledOnce;
+    });
+  });
+
+  describe("when redirects change requestId midflight", () => {
+    let promiseResults;
+    beforeEach(async () => {
+      // init
+      const activeTab = {
+        id: 1,
+        cookieStoreId: "firefox-container-1",
+        url: "https://www.youtube.com",
+        index: 0
+      };
+      await helper.browser.initializeWithTab(activeTab);
+      // assign the activeTab.url
+      await helper.popup.clickElementById("container-page-assigned");
+
+      // http://youtube.com
+      const newTab = {
+        id: 2,
+        cookieStoreId: "firefox-default",
+        url: "http://youtube.com",
+        index: 1,
+        active: true
+      };
+      const promise1 = helper.browser.openNewTab(newTab, {
+        requestId: 1
+      });
+
+      // https://youtube.com
+      const [promise2] = background.browser.webRequest.onBeforeRequest.addListener.yield({
+        frameId: 0,
+        tabId: newTab.id,
+        url: "https://youtube.com",
+        requestId: 1
+      });
+
+      // https://www.youtube.com
+      const [promise3] = background.browser.webRequest.onBeforeRequest.addListener.yield({
+        frameId: 0,
+        tabId: newTab.id,
+        url: "https://www.youtube.com",
+        requestId: 1
+      });
+
+      // https://www.youtube.com
+      const [promise4] = background.browser.webRequest.onBeforeRequest.addListener.yield({
+        frameId: 0,
+        tabId: newTab.id,
+        url: "https://www.youtube.com",
+        requestId: 2
+      });
+
+      promiseResults = await Promise.all([promise1, promise2, promise3, promise4]);
+    });
+
+    it("should not open two confirm pages", async () => {
+      // http://youtube.com is not assigned, no cancel, no reopening
+      expect(promiseResults[0]).to.deep.equal({});
+
+      // https://youtube.com is not assigned, no cancel, no reopening
+      expect(promiseResults[1]).to.deep.equal({});
+
+      // https://www.youtube.com is assigned, this triggers reopening, cancel
+      expect(promiseResults[2]).to.deep.equal({
+        cancel: true
+      });
+
+      // https://www.youtube.com is assigned, this was a redirect, cancel early, no reopening
+      expect(promiseResults[3]).to.deep.equal({
+        cancel: true
+      });
+
+      background.browser.tabs.create.should.have.been.calledOnce;
+    });
+
+    it("should uncancel after webRequest.onCompleted", async () => {
+      const [promise1] = background.browser.webRequest.onCompleted.addListener.yield({
+        tabId: 2
+      });
+      await promise1;
+
+      const [promise2] = background.browser.webRequest.onBeforeRequest.addListener.yield({
+        frameId: 0,
+        tabId: 2,
+        url: "https://www.youtube.com",
+        requestId: 123
+      });
+      await promise2;
+
+      background.browser.tabs.create.should.have.been.calledTwice;
+    });
+
+    it("should uncancel after webRequest.onErrorOccurred", async () => {
+      const [promise1] = background.browser.webRequest.onErrorOccurred.addListener.yield({
+        tabId: 2
+      });
+      await promise1;
+
+      // request to assigned url in same tab
+      const [promise2] = background.browser.webRequest.onBeforeRequest.addListener.yield({
+        frameId: 0,
+        tabId: 2,
+        url: "https://www.youtube.com",
+        requestId: 123
+      });
+      await promise2;
+
+      background.browser.tabs.create.should.have.been.calledTwice;
+    });
+
+    it("should uncancel after 2 seconds", async () => {
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      // request to assigned url in same tab
+      const [promise2] = background.browser.webRequest.onBeforeRequest.addListener.yield({
+        frameId: 0,
+        tabId: 2,
+        url: "https://www.youtube.com",
+        requestId: 123
+      });
+      await promise2;
+
+      background.browser.tabs.create.should.have.been.calledTwice;
+    }).timeout(2002);
+
+    it("should not influence the canceled url in other tabs", async () => {
+      const newTab = {
+        id: 123,
+        cookieStoreId: "firefox-default",
+        url: "https://www.youtube.com",
+        index: 10,
+        active: true
+      };
+      await helper.browser.openNewTab(newTab, {
+        requestId: 321
+      });
+
+      background.browser.tabs.create.should.have.been.calledTwice;
     });
   });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -91,11 +91,11 @@ global.buildPopupDom = async (options = {}) => {
 global.afterEach(() => {
   if (global.background) {
     global.background.dom.window.close();
-    delete global.background.dom;
+    delete global.background;
   }
 
   if (global.popup) {
     global.popup.dom.window.close();
-    delete global.popup.dom;
+    delete global.popup;
   }
 });


### PR DESCRIPTION
As mentioned in #1114 there are still cases where two tabs are opened when redirects are involved:

![mac22](https://user-images.githubusercontent.com/29637501/36125335-df7a2d9e-1053-11e8-83f6-287554c6d949.gif)

In this case `www.youtube.com` is assigned. The initial request goes to `http://youtube.com` which results in redirects to `https://youtube.com` and two times `https://www.youtube.com` - the last request has a different `requestId`. All have the same `tabId`.

To fix this all requestIds and urls that reach the point of being "reopened" are marked as canceled in relation to the tabId - or are canceled if already marked as canceled. Instead of cleaning up canceled requests with a timeout, we can use `webRequest.onCompleted` and `webRequest.onErrorOccurred` - though, since they are not 100% reliable, a 2seconds backup cleanup timer is included (uncanceling is also covered with tests).

The downside of this fix is that, if the user left clicks `http://youtube.com` on a website and switches back to the website, while the confirm page or target container is loading and the completed callback, error callback and backup cleanup timer haven't fired, then all clicks in that tab on the urls marked as canceled will be canceled. I'd personally say that is highly unlikely - the requests complete normally really fast, unless the user has a really slow internet-connection, and even if not after 2seconds the requests get uncanceled - and still preferable in comparison to two tabs opening at random.

Fixes #940 #1003 #1080 #728 #912

---

Some informations when and how the redirects happen:

**First time with clean Network cache in Firefox. 3 requests, all have the same requestId**
```
[requestId: 1] http://youtube.com -[network]-> 301 - onBeforeRedirect fires
[requestId: 1] https://youtube.com -[network]-> 301 - onBeforeRedirect fires
[requestId: 1] https://www.youtube.com
```
![image](https://user-images.githubusercontent.com/29637501/36130641-1caa5ae4-106e-11e8-994f-f2662701029d.png)


**Second time with filled Network cache in Firefox, 4 requests, last has a different requestId**
```
[requestId: 1] http://youtube.com -[internal]-> 301 - onBeforeRedirect doesn't fire
[requestId: 1] https://youtube.com -[network]-> 301 - onBeforeRedirect fires
[requestId: 1] https://www.youtube.com -[internal]-> 301? - onBeforeRedirect doesn't fire
[requestId: 2] https://www.youtube.com
```

![image](https://user-images.githubusercontent.com/29637501/36130558-b0b36542-106d-11e8-95d1-a10ae17f93a8.png)

Filed a [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1437748) since I believe this is not intended behavior. If the requestId wouldn't change or we had a way of correlating the two requests, this fix could be made side-effect-free.