### PR TITLE
Add 'Reopen in container' entry in context menu

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -188,7 +188,7 @@ const assignManager = {
         active: info.frameId !== undefined,
         cookieStoreId: reopenCookieStoreId,
         index: tab.index + 1,
-        openerTabId: tab.id,
+        openerTabId: tab.openerTabId,
         pinned: tab.pinned,
         url: tab.url,
       }).then(() => {
@@ -360,6 +360,20 @@ const assignManager = {
       id: this.MENU_REOPEN_IN,
       title: "Reopen in container",
       contexts: ["all", "tab"],
+    });
+
+    browser.contextMenus.create({
+      id: this.getCookieStoreIdFromReloadMenuId("firefox-default"),
+      title: "Default",
+      contexts: ["all", "tab"],
+      parentId: this.MENU_RELOAD_IN,
+    });
+
+    browser.contextMenus.create({
+      id: "reopen-separator",
+      contexts: ["all", "tab"],
+      type: "separator",
+      parentId: this.MENU_RELOAD_IN,
     });
 
     const identities = await browser.contextualIdentities.query({});

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -1,5 +1,5 @@
 const assignManager = {
-  MENU_REOPEN_IN: "reopen-in-container",
+  MENU_RELOAD_IN: "reopen-in-container",
   MENU_ASSIGN_ID: "open-in-this-container",
   MENU_REMOVE_ID: "remove-open-in-this-container",
   MENU_SEPARATOR_ID: "separator",
@@ -181,7 +181,7 @@ const assignManager = {
   },
 
   async _onClickedHandler(info, tab) {
-    const reopenCookieStoreId = this.menuId2cookieStoreId(info.menuItemId);
+    const reopenCookieStoreId = this.getReloadMenuIdFromCookieStoreId(info.menuItemId);
 
     if (reopenCookieStoreId) {
       const newTab = await browser.tabs.create({
@@ -238,11 +238,11 @@ const assignManager = {
     return backgroundLogic.getUserContextIdFromCookieStoreId(tab.cookieStoreId);
   },
 
-  cookieStoreId2menuId(cookieStoreId) {
+  getCookieStoreIdFromReloadMenuId(cookieStoreId) {
     return "reopen-in-" + cookieStoreId;
   },
 
-  menuId2cookieStoreId(contextMenuId) {
+  getReloadMenuIdFromCookieStoreId(contextMenuId) {
     if (contextMenuId.startsWith("reopen-in-"))
       return contextMenuId.substring(10);
     return false;
@@ -320,41 +320,35 @@ const assignManager = {
     // We also can't change for always private mode
     // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1352102
     browser.contextMenus.remove(this.MENU_ASSIGN_ID);
-    browser.contextualIdentities.query({}).then((identities) => {
-      identities.forEach((identity) => {
-        this.removeContainerMenuEntry(identity);
-      });
-    }).catch(() => {});
-    browser.contextMenus.remove(this.MENU_REOPEN_IN);
+    browser.contextMenus.remove(this.MENU_RELOAD_IN);
     browser.contextMenus.remove(this.MENU_REMOVE_ID);
     browser.contextMenus.remove(this.MENU_SEPARATOR_ID);
     browser.contextMenus.remove(this.MENU_HIDE_ID);
     browser.contextMenus.remove(this.MENU_MOVE_ID);
   },
 
-  addContainerMenuEntry(contextualIdentity, contexts) {
+  addReloadMenuEntry(contextualIdentity, contexts) {
     browser.contextMenus.create({
-      id: this.cookieStoreId2menuId(contextualIdentity.cookieStoreId),
+      id: this.getCookieStoreIdFromReloadMenuId(contextualIdentity.cookieStoreId),
       title: contextualIdentity.name,
       // TODO: colorized icons?
       icons: {
         "16": contextualIdentity.iconUrl
       },
-      // TODO: hide entry for current container in context menu of tabs
       contexts: contexts,
-      parentId: this.MENU_REOPEN_IN,
+      parentId: this.MENU_RELOAD_IN,
     });
   },
 
-  removeContainerMenuEntry(contextualIdentity) {
-    browser.contextMenus.remove(this.cookieStoreId2menuId(contextualIdentity.cookieStoreId));
+  removeReloadMenuEntry(contextualIdentity) {
+    browser.contextMenus.remove(this.getCookieStoreIdFromReloadMenuId(contextualIdentity.cookieStoreId));
   },
 
   async calculateContextMenu(tab) {
     this.removeContextMenu();
 
     browser.contextMenus.create({
-      id: this.MENU_REOPEN_IN,
+      id: this.MENU_RELOAD_IN,
       title: "Reopen in container",
       contexts: ["all", "tab"],
     });

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -325,7 +325,7 @@ const assignManager = {
     browser.contextMenus.remove(this.MENU_ASSIGN_ID);
     browser.contextualIdentities.query({}).then((identities) => {
       identities.forEach((identity) => {
-        browser.contextMenus.remove(this.cookieStoreId2menuId(identity.cookieStoreId));
+        this.removeContainerMenuEntry(identity);
       });
     }).catch(() => {});
     browser.contextMenus.remove(this.MENU_REOPEN_IN);
@@ -333,6 +333,24 @@ const assignManager = {
     browser.contextMenus.remove(this.MENU_SEPARATOR_ID);
     browser.contextMenus.remove(this.MENU_HIDE_ID);
     browser.contextMenus.remove(this.MENU_MOVE_ID);
+  },
+
+  addContainerMenuEntry(contextualIdentity, contexts) {
+    browser.contextMenus.create({
+      id: this.cookieStoreId2menuId(contextualIdentity.cookieStoreId),
+      title: contextualIdentity.name,
+      // TODO: colorized icons?
+      icons: {
+        "16": contextualIdentity.iconUrl
+      },
+      // TODO: hide entry for current container in context menu of tabs
+      contexts: contexts,
+      parentId: this.MENU_REOPEN_IN,
+    });
+  },
+
+  removeContainerMenuEntry(contextualIdentity) {
+    browser.contextMenus.remove(this.cookieStoreId2menuId(contextualIdentity.cookieStoreId));
   },
 
   async calculateContextMenu(tab) {
@@ -346,18 +364,8 @@ const assignManager = {
 
     const identities = await browser.contextualIdentities.query({});
     identities.forEach((identity) => {
-      browser.contextMenus.create({
-        id: this.cookieStoreId2menuId(identity.cookieStoreId),
-        title: identity.name,
-        // TODO: colorized icons?
-        icons: {
-          "16": identity.iconUrl
-        },
-        // TODO: hide entry for current container in context menu of tabs
-        contexts: (identity.cookieStoreId !== tab.cookieStoreId) ?
-                   ["all", "tab"] : ["tab"],
-        parentId: this.MENU_REOPEN_IN,
-      });
+      this.addContainerMenuEntry(identity, (identity.cookieStoreId !== tab.cookieStoreId) ?
+                                      ["all", "tab"] : ["tab"]);
     });
 
     const siteSettings = await this._getAssignment(tab);

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -193,6 +193,8 @@ const assignManager = {
         url: tab.url,
       }).then(() => {
         browser.tabs.remove(tab.id);
+      }).catch((e) => {
+        throw e;
       });
       return;
     }
@@ -325,7 +327,7 @@ const assignManager = {
       identities.forEach((identity) => {
         browser.contextMenus.remove(this.cookieStoreId2menuId(identity.cookieStoreId));
       });
-    });
+    }).catch(() => {});
     browser.contextMenus.remove(this.MENU_REOPEN_IN);
     browser.contextMenus.remove(this.MENU_REMOVE_ID);
     browser.contextMenus.remove(this.MENU_SEPARATOR_ID);

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -192,6 +192,7 @@ const assignManager = {
         pinned: tab.pinned,
         url: tab.url,
       });
+      browser.tabs.update(newTab.id, {"muted": tab.mutedInfo.muted});
       browser.tabs.remove(tab.id);
       return;
     }

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -4,6 +4,7 @@ const messageHandler = {
   // If this were in platform we would change how the tab opens based on "new tab" link navigations such as ctrl+click
   LAST_CREATED_TAB_TIMER: 2000,
   unhideQueue: [],
+  activeTab: -1,
 
   init() {
     // Handles messages from webextension code
@@ -89,6 +90,7 @@ const messageHandler = {
 
     browser.tabs.onActivated.addListener((info) => {
       assignManager.removeContextMenu();
+      this.activeTab = info.tabId;
       browser.tabs.get(info.tabId).then((tab) => {
         assignManager.calculateContextMenu(tab);
       }).catch((e) => {
@@ -106,11 +108,15 @@ const messageHandler = {
       }
       assignManager.removeContextMenu();
 
-      browser.tabs.get(details.tabId).then((tab) => {
-        assignManager.calculateContextMenu(tab);
-      }).catch((e) => {
-        throw e;
-      });
+      // make sure to update the context menu only if the request was completed
+      // for the currently active tab
+      if (details.tabId === this.activeTab) {
+        browser.tabs.get(details.tabId).then((tab) => {
+          assignManager.calculateContextMenu(tab);
+        }).catch((e) => {
+          throw e;
+        });
+      }
     }, {urls: ["<all_urls>"], types: ["main_frame"]});
 
     browser.tabs.onCreated.addListener((tab) => {

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -76,6 +76,14 @@ const messageHandler = {
       browser.contextualIdentities.onRemoved.addListener(({contextualIdentity}) => {
         const userContextId = backgroundLogic.getUserContextIdFromCookieStoreId(contextualIdentity.cookieStoreId);
         backgroundLogic.deleteContainer(userContextId, true);
+
+        assignManager.removeContainerMenuEntry(contextualIdentity);
+      });
+    }
+
+    if (browser.contextualIdentities.onCreated) {
+      browser.contextualIdentities.onCreated.addListener(({contextualIdentity}) => {
+        assignManager.addContainerMenuEntry(contextualIdentity, ["all", "tab"])
       });
     }
 

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -83,7 +83,7 @@ const messageHandler = {
 
     if (browser.contextualIdentities.onCreated) {
       browser.contextualIdentities.onCreated.addListener(({contextualIdentity}) => {
-        assignManager.addContainerMenuEntry(contextualIdentity, ["all", "tab"])
+        assignManager.addContainerMenuEntry(contextualIdentity, ["all", "tab"]);
       });
     }
 

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -78,13 +78,13 @@ const messageHandler = {
         const userContextId = backgroundLogic.getUserContextIdFromCookieStoreId(contextualIdentity.cookieStoreId);
         backgroundLogic.deleteContainer(userContextId, true);
 
-        assignManager.removeContainerMenuEntry(contextualIdentity);
+        assignManager.removeReloadMenuEntry(contextualIdentity);
       });
     }
 
     if (browser.contextualIdentities.onCreated) {
       browser.contextualIdentities.onCreated.addListener(({contextualIdentity}) => {
-        assignManager.addContainerMenuEntry(contextualIdentity, ["all", "tab"]);
+        assignManager.addReloadMenuEntry(contextualIdentity, ["all", "tab"]);
       });
     }
 


### PR DESCRIPTION
Adds a new entry in the context menu of tabs and websites that allows the user to reopen the current tab in a different container.
This PR extends features introduced in #986 and fixes #1124.

There are three more ways how to improve my solution:

- In the context menu of a website, all containers are shown except the container of the current tab.
However, I could not find a way to achieve the same for the context menu in tabs, thus all containers are shown there.
- Make it possible to reopen a tab in the default container. I tried opening a new tab with `cookieStorageId = 'firefox-default'` and no `cookieStorageId`, but Firefox seems to automatically open the tab in the current container.
- The icons for the menu entries could be colourized.
