### PR TITLE
Add keyboard shortcut for showing tabs for a container in popup

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -523,6 +523,12 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       case 38:
         previous();
         break;
+      case 39:
+        const showTabs = element.parentNode.querySelector(".show-tabs");
+        if (showTabs) {
+          showTabs.click();
+        }
+        break;
       default:
         if ((e.keyCode >= 49 && e.keyCode <= 57) &&
             Logic._currentPanel === "containersList") {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -523,12 +523,13 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       case 38:
         previous();
         break;
-      case 39:
+      case 39: {
         const showTabs = element.parentNode.querySelector(".show-tabs");
         if (showTabs) {
           showTabs.click();
         }
         break;
+      }
       default:
         if ((e.keyCode >= 49 && e.keyCode <= 57) &&
             Logic._currentPanel === "containersList") {


### PR DESCRIPTION
When the browser popup menu for Containers is open, a specific Container is selected, and the right arrow to expose the submenu is visible for that Container, pressing the right arrow keyboard button
takes you to the submenu.

Fixes #1009