### PR TITLE
Exempt tabs from container rechecking when they are opened from the same host

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -136,6 +136,19 @@ const assignManager = {
       this.deleteContainer(siteSettings.userContextId);
       return {};
     }
+
+    // If a page has been opened in a nonstandard container, the exemption flag for that
+    //   tab will have been set, so following links in the same tab will not trigger new
+    //   prompts about the container in which to open the page. However, opening links
+    //   in a new tab will not be subject to this protection.
+    // To prevent this, explicitly allow requests that don't change host to go through.
+    if(options.originUrl) {
+        const originUrl = new window.URL(options.originUrl);
+        const newUrl = new window.URL(options.url);
+        if(originUrl.hostname === newUrl.hostname)
+            return {};
+    }
+
     const userContextId = this.getUserContextIdFromCookieStore(tab);
     if (!siteSettings
         || userContextId === siteSettings.userContextId

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -145,8 +145,12 @@ const assignManager = {
     if(options.originUrl) {
         const originUrl = new window.URL(options.originUrl);
         const newUrl = new window.URL(options.url);
-        if(originUrl.hostname === newUrl.hostname)
+        if(originUrl.hostname === newUrl.hostname) {
+            // in fact, set this URL-tab combo exempted so future manual browsing
+            // within it does also not trigger new prompts
+            this.storageArea.setExempted(options.url, options.tabId);
             return {};
+        }
     }
 
     const userContextId = this.getUserContextIdFromCookieStore(tab);


### PR DESCRIPTION
Right now, while the exemption mechanism ensures that you can freely follow links within a domain that has been opened in a different container from the one that it has been assigned to "Always (...) Open in (...)", it does not work when you middle-click to open a link in a new tab. The result is that, for instance, when using containers to log into a website such as github with a nonstandard account while also using middle-click to open new tabs frequently, the user experience is terrible (you get redirected to the confirmation page every single time). (This is exacerbated by the confirmation page interacting badly with addons such as Tree Style Tab.)

Since, as far as I can tell, there is no compelling privacy scenario requiring that you reobtain the user's consent to use nonstandard container C when following a link on host X to open a new tab on the same host (and, as far as I can tell, this is the only class of scenarios in which originUrl and newUrl are on the same host, the active container is not standard for that host and the exemption flag is not set), I propose the following hopefully self-explanatory code fragment to make it so that requests within the same domain always go through and result in a container exemption being set for the tab.