### PR TITLE
Allow Webextensions to get,set and remove  assignments

### DIFF
--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -90,6 +90,27 @@ const messageHandler = {
         }
         response = assignManager.storageArea.get(message.url);
         break;
+      case "getAssignmentObjectByContainer":
+        if (typeof message.userContextId === "undefined") {
+          throw new Error("Missing message.userContextId");
+        }
+        response = Object.values(assignManager.storageArea.getByContainer(message.userContextId));
+        break;
+      case "setAssignment":
+        if (typeof message.userContextId === "undefined") {
+          throw new Error("Missing message.userContextId");
+        }
+        if (typeof message.neverAsk === "undefined") {
+          throw new Error("Missing message.neverAsk");
+        }
+        response = assignManager.storageArea.set(message.url, { userContextId: message.userContextId, neverAsk: message.neverAsk});
+        break;
+      case "removeAssignment":
+        if (typeof message.url === "undefined") {
+          throw new Error("Missing message.url");
+        }
+        response = assignManager.storageArea.remove(message.url);
+        break;
       default:
         throw new Error("Unknown message.method");
       }


### PR DESCRIPTION
Hi,

I'm  the author of the [containers-sync](https://addons.mozilla.org/en-US/firefox/addon/containers-sync/) extension and I have been getting requests to sync assignments along with containers.

Taking inspiration from #1095 , I added a few more enhancements which would enable extensions with "contextualIdentities" permission to get all assignments for a container, set and remove assignments.

