### PR TITLE
Add Reopen in Container context menu for tab

### DIFF
--- a/src/js/background/index.html
+++ b/src/js/background/index.html
@@ -11,6 +11,7 @@
       "js/background/badge.js",
       "js/background/identityState.js",
       "js/background/messageHandler.js",
+      "js/background/reopen.js",
     ]
 -->
     <script type="text/javascript" src="backgroundLogic.js"></script>
@@ -18,5 +19,6 @@
     <script type="text/javascript" src="badge.js"></script>
     <script type="text/javascript" src="identityState.js"></script>
     <script type="text/javascript" src="messageHandler.js"></script>
+    <script type="text/javascript" src="reopen.js"></script>
   </body>
 </html>

--- a/src/js/background/reopen.js
+++ b/src/js/background/reopen.js
@@ -1,0 +1,69 @@
+const reopenIn = {
+  // Map from menuItemId to cookieStoreId.
+  cookieStoreIds: new Map(),
+
+  init() {
+    browser.menus.onShown.addListener(async (info, tab) => {
+      if (info.contexts.length !== 1) {
+        return;
+      }
+      if (info.contexts[0] !== "tab") {
+        return;
+      }
+
+      await this.rebuildMenu(tab);
+    });
+
+    browser.menus.onClicked.addListener((info, tab) => {
+      browser.tabs.create({
+        url: tab.url,
+        index: tab.index + 1,
+        cookieStoreId: this.cookieStoreIds.get(info.menuItemId)
+      });
+    });
+  },
+
+  async rebuildMenu(tab) {
+    browser.menus.removeAll();
+
+    const containers = await browser.contextualIdentities.query({});
+
+    const folderId = browser.menus.create({
+      title: "Reopen in Container",
+      contexts: ["tab"],
+    });
+
+    if (tab.cookieStoreId !== "firefox-default") {
+      const menuItemId = "openin-firefox-default";
+      this.cookieStoreIds.set(menuItemId, "firefox-default");
+      browser.menus.create({
+        id: menuItemId,
+        title: "No Container",
+        parentId: folderId,
+      });
+      browser.menus.create({
+        type: "separator",
+        parentId: folderId,
+      });
+    }
+
+    for (const [i, container] of containers.entries()) {
+      if (container.cookieStoreId === tab.cookieStoreId)
+        continue;
+
+      const menuItemId = "openin-" + i;
+      this.cookieStoreIds.set(menuItemId, container.cookieStoreId);
+      browser.menus.create({
+        id: menuItemId,
+        title: container.name,
+        icons: {
+          "16": container.iconUrl,
+        },
+        parentId: folderId,
+      });
+    }
+
+    browser.menus.refresh();
+  },
+};
+reopenIn.init();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,6 +27,7 @@
     "history",
     "idle",
     "management",
+    "menus",
     "storage",
     "tabs",
     "webRequestBlocking",

--- a/test/browser.mock.js
+++ b/test/browser.mock.js
@@ -80,6 +80,17 @@ module.exports = () => {
         addListener: sinon.stub()
       }
     },
+    menus: {
+      create: sinon.stub(),
+      onClicked: {
+        addListener: sinon.stub()
+      },
+      onShown: {
+        addListener: sinon.stub()
+      },
+      refresh: sinon.stub(),
+      removeAll: sinon.stub()
+    },
     extension: {
       getURL: sinon.stub().returns("moz-extension://multi-account-containers/confirm-page.html")
     }


### PR DESCRIPTION
Simple port of https://bugzilla.mozilla.org/show_bug.cgi?id=1376119 patch to extension.
which fixes #942.

This patch adds "Reopen in Container" menu into tab menu, which reopens the current tab into the new foreground tab with the specified container.
(doesn't touch/remove the current tab)

the difference between this and the patch above:
 * the menu item is shown at the bottom, instead of under "Duplicate Tab"
 * the container icon's color is not reflected (since WebExtensions' menu doesn't support it)

also, currently this patch doesn't have test.
