### PR TITLE
#1028 resolves focus name field on opening new container sub-panel

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1001,6 +1001,12 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
 
     document.querySelector("#edit-container-panel-name-input").value = identity.name || "";
     document.querySelector("#edit-container-panel-usercontext-input").value = userContextId || NEW_CONTAINER_ID;
+    const containerName = document.querySelector("#edit-container-panel-name-input");
+    setTimeout(function()
+    { 
+      containerName.focus(); 
+      containerName.select();  
+    }, 0);
     [...document.querySelectorAll("[name='container-color']")].forEach(colorInput => {
       colorInput.checked = colorInput.value === identity.color;
     });
@@ -1015,7 +1021,6 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
 
 // P_CONTAINER_DELETE: Delete a container.
 // ----------------------------------------------------------------------------
-
 Logic.registerPanel(P_CONTAINER_DELETE, {
   panelSelector: "#delete-container-panel",
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1002,11 +1002,10 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     document.querySelector("#edit-container-panel-name-input").value = identity.name || "";
     document.querySelector("#edit-container-panel-usercontext-input").value = userContextId || NEW_CONTAINER_ID;
     const containerName = document.querySelector("#edit-container-panel-name-input");
-    setTimeout(function()
-    { 
-      containerName.focus(); 
-      containerName.select();  
-    }, 0);
+    window.requestAnimationFrame(() => {
+      containerName.select();
+      containerName.focus();
+    });
     [...document.querySelectorAll("[name='container-color']")].forEach(colorInput => {
       colorInput.checked = colorInput.value === identity.color;
     });

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1021,6 +1021,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
 
 // P_CONTAINER_DELETE: Delete a container.
 // ----------------------------------------------------------------------------
+
 Logic.registerPanel(P_CONTAINER_DELETE, {
   panelSelector: "#delete-container-panel",
 


### PR DESCRIPTION
## Fixes #1028 

### AFTER:
![webp net-gifmaker 2](https://user-images.githubusercontent.com/35342019/45874195-e134e000-bdb1-11e8-86ae-38bb0e159c7c.gif)


### DESCRIPTION:
- Following the thread of the issue, I found the discussion is absolutely correct about the `focus()`

- After searching for hours the reason I found was interesting and weird; The solution was to "pause" the JavaScript execution to let the rendering threads catch up. And this is the effect that `setTimeout()` with a timeout of 0 does. For better understanding, you can refer this link [here](https://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful)
- For even better understanding, answer your curiosity by watching [this](https://www.youtube.com/watch?v=8aGhZQkoFbQ) 😄.
- The `select()` and `focus()` both work fine but `focus()` seems to be hidden by the input box-shadow. 