### PR TITLE
#256 disables edit-container button when no container is present

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -45,6 +45,7 @@ body {
   --small-text-size: 0.833rem; /* 10px */
   --small-radius: 3px;
   --icon-button-size: calc(calc(var(--block-line-separation-size) * 2) + 1.66rem); /* 20px */
+  --inactive-opacity: 0.3;
 }
 
 @media (min-resolution: 1dppx) {
@@ -576,6 +577,11 @@ span ~ .panel-header-text {
 
 .edit-containers-panel .userContext-wrapper {
   max-inline-size: 204px;
+}
+
+.disable-edit-containers {
+  opacity: var(--inactive-opacity);
+  pointer-events: none;
 }
 
 .userContext-wrapper {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -507,7 +507,9 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
     });
 
     Logic.addEnterHandler(document.querySelector("#edit-containers-link"), () => {
-      Logic.showPanel(P_CONTAINERS_EDIT);
+      if (!document.querySelector("#edit-containers").classList.contains("disable-edit-containers")){
+        Logic.showPanel(P_CONTAINERS_EDIT);
+      }
     });
 
     Logic.addEnterHandler(document.querySelector("#sort-containers-link"), async function () {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -506,8 +506,8 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       Logic.showPanel(P_CONTAINER_EDIT, { name: Logic.generateIdentityName() });
     });
 
-    Logic.addEnterHandler(document.querySelector("#edit-containers-link"), () => {
-      if (!document.querySelector("#edit-containers").classList.contains("disable-edit-containers")){
+    Logic.addEnterHandler(document.querySelector("#edit-containers-link"), (e) => {
+      if (!e.target.classList.contains("disable-edit-containers")){
         Logic.showPanel(P_CONTAINERS_EDIT);
       }
     });
@@ -690,7 +690,7 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       document.removeEventListener("focus", focusHandler);
     });
     /*  If no container is present disable the Edit Containers button */
-    const editContainer = document.querySelector("#edit-containers");
+    const editContainer = document.querySelector("#edit-containers-link");
     if (Logic.identities().length === 0) {
       editContainer.classList.add("disable-edit-containers");
     } else {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -687,6 +687,13 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
     document.addEventListener("mousedown", () => {
       document.removeEventListener("focus", focusHandler);
     });
+    /*  If no container is present disable the Edit Containers button */
+    const editContainer = document.querySelector("#edit-containers");
+    if (Logic.identities().length === 0) {
+      editContainer.classList.add("disable-edit-containers");
+    } else {
+      editContainer.classList.remove("disable-edit-containers");
+    }
 
     return Promise.resolve();
   },

--- a/src/popup.html
+++ b/src/popup.html
@@ -116,7 +116,7 @@
       </table>
     </div>
     <div class="panel-footer edit-identities">
-      <div class="edit-containers-text panel-footer-secondary">
+      <div class="edit-containers-text panel-footer-secondary" id="edit-containers">
         <a href="#" tabindex="0" id="edit-containers-link">Edit Containers</a>
       </div>
       <a href="#" tabindex="0" class="add-container-link pop-button" id="container-add-link" title="Create new container">

--- a/src/popup.html
+++ b/src/popup.html
@@ -116,7 +116,7 @@
       </table>
     </div>
     <div class="panel-footer edit-identities">
-      <div class="edit-containers-text panel-footer-secondary" id="edit-containers">
+      <div class="edit-containers-text panel-footer-secondary">
         <a href="#" tabindex="0" id="edit-containers-link">Edit Containers</a>
       </div>
       <a href="#" tabindex="0" class="add-container-link pop-button" id="container-add-link" title="Create new container">


### PR DESCRIPTION
## Fixes #256 

### AFTER:
![webp net-gifmaker](https://user-images.githubusercontent.com/35342019/46179667-ee822b00-c2d9-11e8-9966-ad99175d44bb.gif)


### DESCRIPTION:
- Resolves the clickable `Edit Container` button even after no container is present.