### PR TITLE
list sites which always load with container

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -685,6 +685,16 @@ span ~ .panel-header-text {
   padding-inline-start: 16px;
 }
 
+ul.container-info-url-list {
+  font-size: 14px;
+  list-style-type: none;
+  padding-left: 16px;
+}
+
+li.container-info-url-item {
+  padding-left: 16px;
+}
+
 .container-info-has-tabs img,
 .container-info-tab-row img {
   block-size: 16px;
@@ -700,7 +710,8 @@ span ~ .panel-header-text {
   max-inline-size: 200px;
 }
 
-.container-info-list {
+.container-info-list,
+.container-url-list {
   display: flex;
   flex-direction: column;
   margin-block-start: 4px;

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -112,6 +112,28 @@ const backgroundLogic = {
     return list.concat(containerState.hiddenTabs);
   },
 
+  async getUrlsForContainer(options) {
+    const requiredArguments = ["cookieStoreId"];
+    this.checkArgs(requiredArguments, options, "getUrlsForContainer");
+    const { cookieStoreId } = options;
+
+    const userContextId = this.getUserContextIdFromCookieStoreId(cookieStoreId);
+
+    let siteStoreKeyBase = assignManager.storageArea.getSiteStoreKey("http://x");
+    siteStoreKeyBase = siteStoreKeyBase.slice(0, siteStoreKeyBase.length-1);
+    let isSiteStorageKey = new RegExp("^" + siteStoreKeyBase);
+    isSiteStorageKey = isSiteStorageKey.test.bind(isSiteStorageKey);
+
+    const containerUrls = [];
+    for (const [key, value] of Object.entries(await browser.storage.local.get())) {
+      if (isSiteStorageKey(key) && value.userContextId === userContextId) {
+        containerUrls.push(key.slice(siteStoreKeyBase.length));
+      }
+    }
+
+    return containerUrls;
+  },
+
   async moveTabsToWindow(options) {
     const requiredArguments = ["cookieStoreId", "windowId"];
     this.checkArgs(requiredArguments, options, "moveTabsToWindow");

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -62,6 +62,11 @@ const messageHandler = {
           windowId: m.windowId
         });
         break;
+      case "getUrlsForContainer":
+        response = backgroundLogic.getUrlsForContainer({
+          cookieStoreId: m.cookieStoreId,
+        });
+        break;
       case "queryIdentitiesState":
         response = backgroundLogic.queryIdentitiesState(m.message.windowId);
         break;

--- a/src/popup.html
+++ b/src/popup.html
@@ -145,6 +145,10 @@
           <table id="container-info-table" class="container-info-list">
           </table>
         </div>
+        <div class="scrollable container-info-urls">
+          <h3 id="container-info-urls-name" class="panel-header-text container-name truncate-text"></h3>
+          <ul id="container-info-urls" class="container-info-url-list"></ul>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Thanks for building this addon!  It's really great and I really love the
functionality it provides.  I have a small change that I'd like to make.
It's motivated by my personal frustration with trying to figure out what
is supposed to load in a specific container.

The data storage system used is optimized for quick lookups on webpage
load, which is the right choice.  Instead of changing that, I decided
instead to iterate through the full data storage and pick out the
relevant items and trace them back to the container that they belong to
for display.  I suspect that with the size of the data storage, it's
probably fine.  Other than building a mapping in a different key of the
local storage when adding a site to a container, I don't see any way to
make this quicker on lookup.

I'm not at all an extension developer, nor do I write a lot of html or
css.  I probably butchered the display portion of this, but it mostly
works...  I would not expect this patch to merge in this state, but I'd
be interested in working on making it possible to merge.  Maybe hiding
this functionality behind an addon preference?

If this functionality isn't desirable in the official addon, is there
anything which would block me from submitting a fork to
addons.mozilla.org?  It's primarily because I'd like to use it on a
release copy of firefox, and so I'd need it signed by addons.