### PR TITLE
Fixes #1109 , rest of #791

### DIFF
--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -3,7 +3,6 @@ const messageHandler = {
   // We use this to catch redirected tabs that have just opened
   // If this were in platform we would change how the tab opens based on "new tab" link navigations such as ctrl+click
   LAST_CREATED_TAB_TIMER: 2000,
-  unhideQueue: [],
 
   init() {
     // Handles messages from webextension code
@@ -39,7 +38,7 @@ const messageHandler = {
         backgroundLogic.sortTabs();
         break;
       case "showTabs":
-        this.unhideContainer(m.cookieStoreId);
+        backgroundLogic.unhideContainer(m.cookieStoreId);
         break;
       case "hideTabs":
         backgroundLogic.hideTabs({
@@ -156,7 +155,7 @@ const messageHandler = {
           this.incrementCountOfContainerTabsOpened();
         }
 
-        this.unhideContainer(tab.cookieStoreId);
+        backgroundLogic.unhideContainer(tab.cookieStoreId);
       }
       setTimeout(() => {
         this.lastCreatedTab = null;
@@ -179,17 +178,6 @@ const messageHandler = {
       browser.storage.local.set({achievements});
       browser.browserAction.setBadgeBackgroundColor({color: "rgba(0,217,0,255)"});
       browser.browserAction.setBadgeText({text: "NEW"});
-    }
-  },
-
-  async unhideContainer(cookieStoreId) {
-    if (!this.unhideQueue.includes(cookieStoreId)) {
-      this.unhideQueue.push(cookieStoreId);
-      // Unhide all hidden tabs
-      await backgroundLogic.showTabs({
-        cookieStoreId
-      });
-      this.unhideQueue.splice(this.unhideQueue.indexOf(cookieStoreId), 1);
     }
   },
 


### PR DESCRIPTION
Moving tabs to a new window for a hidden container was resulting in two of every tab being opened in a new container. 

This seemed to be happening because :- 
`moveTabsToWindow` has logic within it to show hidden tabs and does so by reading the `containerState`, getting the hidden tabs information, opening the hidden tabs and then writing back the new `containerState`. In addition, when a new tab is created, an event is fired to unhide the container using the `showTabs` method. `showTabs` too reads `containerState` (information about the hidden tabs) from the cookie. However, it seems like `showTabs` reads it before `moveTabsToWindow` finishes writing the updated state. `showTabs` too, therefore, proceeds to show all hidden tabs

This PR contains code that modifies each of those functions to first check if the container is already in a `unhideQueue` and only open if it isn't. It reuses the same logic which was previously present in `messageHandler.js` but now moves it to `backgroundLogic.js` 

Ran the tests and they seemed to be running fine except for one which seemed unrelated and also seems to be failing on master. Wasn't really sure what to do with that.