### PR TITLE
exempting `always open in` functionality for non-standard ports

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -12,7 +12,11 @@ const assignManager = {
     getSiteStoreKey(pageUrl) {
       const url = new window.URL(pageUrl);
       const storagePrefix = "siteContainerMap@@_";
-      return `${storagePrefix}${url.hostname}`;
+      if (url.port === "80" || url.port === "443") {
+        return `${storagePrefix}${url.hostname}`;
+      } else {
+        return `${storagePrefix}${url.hostname}${url.port}`;
+      }
     },
 
     setExempted(pageUrl, tabId) {


### PR DESCRIPTION
### [Fixes #985 ]
#### Exempting `always open in` functionality for all ports other than 80 and 443
- Not sure if this is what we wanted, but it seems to work as far as I tested it. 
