### PR TITLE
Fix the tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes eol=lf
+*.js eol=lf

--- a/test/issues/940.test.js
+++ b/test/issues/940.test.js
@@ -160,7 +160,7 @@ describe("#940", () => {
       await promise2;
 
       background.browser.tabs.create.should.have.been.calledTwice;
-    }).timeout(2002);
+    }).timeout(2500);
 
     it("should not influence the canceled url in other tabs", async () => {
       const newTab = {


### PR DESCRIPTION
The tests really expect the files to be checked out with LF-only line endings. Let's declare that!

And also, give one test a bit more time, as it takes a little longer on Windows (probably due to file I/O).