### PR TITLE
Avoid using explicitOriginalTarget on confirm-page

### DIFF
--- a/src/js/confirm-page.js
+++ b/src/js/confirm-page.js
@@ -18,17 +18,13 @@ async function load() {
     document.getElementById("current-container-name").textContent = currentContainer.name;
   }
 
-  document.getElementById("redirect-form").addEventListener("submit", (e) => {
+  document.getElementById("confirm").addEventListener("click", (e) => {
     e.preventDefault();
-    const buttonTarget = e.explicitOriginalTarget;
-    switch (buttonTarget.id) {
-    case "confirm":
-      confirmSubmit(redirectUrl, cookieStoreId);
-      break;
-    case "deny":
-      denySubmit(redirectUrl);
-      break;
-    }
+    confirmSubmit(redirectUrl, cookieStoreId);
+  });
+  document.getElementById("deny").addEventListener("click", (e) => {
+    e.preventDefault();
+    denySubmit(redirectUrl);
   });
 }
 


### PR DESCRIPTION
`explicitOriginalTarget.id` is randomly set or empty which prevents the confirm page from working properly. This should probably also get reported on Bugzilla. The included workaround adds the listeners directly to the buttons which works reliably.

Fixes #1331