### PR TITLE
Possible changes to fix #1367

### DIFF
--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -1,6 +1,6 @@
 const DEFAULT_TAB = "about:newtab";
-const BROWSER_NAME = (await browser.runtime.getBrowserInfo()).name.toLowerCase();
 const backgroundLogic = {
+  BROWSER_NAME: (await browser.runtime.getBrowserInfo()).name.toLowerCase(),
   NEW_TAB_PAGES: new Set([
     "about:startpage",
     "about:newtab",
@@ -20,7 +20,7 @@ const backgroundLogic = {
     if (!cookieStoreId) {
       return false;
     }
-    const container = cookieStoreId.replace(BROWSER_NAME + "-container-", "");
+    const container = cookieStoreId.replace(this.BROWSER_NAME + "-container-", "");
     if (container !== cookieStoreId) {
       return container;
     }

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -1,4 +1,5 @@
 const DEFAULT_TAB = "about:newtab";
+const BROWSER_NAME = (await browser.runtime.getBrowserInfo()).name.toLowerCase();
 const backgroundLogic = {
   NEW_TAB_PAGES: new Set([
     "about:startpage",
@@ -19,7 +20,7 @@ const backgroundLogic = {
     if (!cookieStoreId) {
       return false;
     }
-    const container = cookieStoreId.replace("firefox-container-", "");
+    const container = cookieStoreId.replace(BROWSER_NAME + "-container-", "");
     if (container !== cookieStoreId) {
       return container;
     }
@@ -324,6 +325,6 @@ const backgroundLogic = {
   },
 
   cookieStoreId(userContextId) {
-    return `firefox-container-${userContextId}`;
+    return BROWSER_NAME + `-container-${userContextId}`;
   }
 };

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -3,6 +3,7 @@ const messageHandler = {
   // We use this to catch redirected tabs that have just opened
   // If this were in platform we would change how the tab opens based on "new tab" link navigations such as ctrl+click
   LAST_CREATED_TAB_TIMER: 2000,
+  BROWSER_NAME = (await browser.runtime.getBrowserInfo()).name.toLowerCase(),
 
   init() {
     // Handles messages from webextension code
@@ -148,8 +149,8 @@ const messageHandler = {
       this.lastCreatedTab = tab;
       if (tab.cookieStoreId) {
         // Don't count firefox-default, firefox-private, nor our own confirm page loads
-        if (tab.cookieStoreId !== "firefox-default" &&
-            tab.cookieStoreId !== "firefox-private" &&
+        if (tab.cookieStoreId !== this.BROWSER_NAME + "-default" &&
+            tab.cookieStoreId !== this.BROWSER_NAME + "-private" &&
             !tab.url.startsWith("moz-extension")) {
           // increment the counter of container tabs opened
           this.incrementCountOfContainerTabsOpened();

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -3,7 +3,7 @@ const messageHandler = {
   // We use this to catch redirected tabs that have just opened
   // If this were in platform we would change how the tab opens based on "new tab" link navigations such as ctrl+click
   LAST_CREATED_TAB_TIMER: 2000,
-  BROWSER_NAME = (await browser.runtime.getBrowserInfo()).name.toLowerCase(),
+  BROWSER_NAME: (await browser.runtime.getBrowserInfo()).name.toLowerCase(),
 
   init() {
     // Handles messages from webextension code

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -9,6 +9,7 @@ const DEFAULT_COLOR = "blue";
 const DEFAULT_ICON = "circle";
 const NEW_CONTAINER_ID = "new";
 
+const BROWSER_NAME = (await browser.runtime.getBrowserInfo()).name.toLowerCase();
 const ONBOARDING_STORAGE_KEY = "onboarding-stage";
 
 // List of panels
@@ -202,7 +203,7 @@ const Logic = {
   },
 
   userContextId(cookieStoreId = "") {
-    const userContextId = cookieStoreId.replace("firefox-container-", "");
+    const userContextId = cookieStoreId.replace(BROWSER_NAME + "-container-", "");
     return (userContextId !== cookieStoreId) ? Number(userContextId) : false;
   },
 


### PR DESCRIPTION
Using a dynamic method to get the container cookie id prefix to avoid hard coded prefixes that are incorrect in re-branded Firefox forks.