### PR TITLE
Bug 1539507 - Fix targeting of button click when button element isn't…

### DIFF
--- a/src/js/confirm-page.js
+++ b/src/js/confirm-page.js
@@ -20,13 +20,20 @@ async function load() {
 
   document.getElementById("redirect-form").addEventListener("submit", (e) => {
     e.preventDefault();
-    const buttonTarget = e.explicitOriginalTarget;
-    switch (buttonTarget.id) {
-    case "confirm":
-      confirmSubmit(redirectUrl, cookieStoreId);
-      break;
+    let button = "confirm"; // Confirm is the form default.
+    let buttonTarget = e.explicitOriginalTarget;
+    if (buttonTarget.tagName !== "BUTTON") {
+      buttonTarget = buttonTarget.closest("button");
+    }
+    if (buttonTarget && buttonTarget.id) {
+      button = buttonTarget.id;
+    }
+    switch (button) {
     case "deny":
       denySubmit(redirectUrl);
+      break;
+    case "confirm":
+      confirmSubmit(redirectUrl, cookieStoreId);
       break;
     }
   });


### PR DESCRIPTION
… clicked.

TL;DR is that the `explicitOriginalTarget` appears to have been changed to not be always the button. A better fix might be to stop using it and use a global to store the last clicked button on the form. I'm pretty suprised there isn't a more elegant way to get this info :/