### PR TITLE
Default favicon now displays for Edit Containers panel (issue #1314)

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -985,7 +985,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
         const trElement = document.createElement("div");
         /* As we don't have the full or correct path the best we can assume is the path is HTTPS and then replace with a broken icon later if it doesn't load.
            This is pending a better solution for favicons from web extensions */
-        const assumedUrl = `https://${site.hostname}`;
+        const assumedUrl = `https://${site.hostname}/favicon.ico`;
         trElement.innerHTML = escaped`
         <div></div>
         <div title="${site.hostname}" class="truncate-text hostname">

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -987,7 +987,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
            This is pending a better solution for favicons from web extensions */
         const assumedUrl = `https://${site.hostname}/favicon.ico`;
         trElement.innerHTML = escaped`
-        <div></div>
+        <div class="favicon"></div>
         <div title="${site.hostname}" class="truncate-text hostname">
           ${site.hostname}
         </div>
@@ -995,7 +995,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
           class="pop-button-image delete-assignment"
           src="/img/container-delete.svg"
         />`;
-        trElement.querySelector("div").appendChild(Utils.createFavIconElement(assumedUrl));
+        trElement.getElementsByClassName("favicon")[0].appendChild(Utils.createFavIconElement(assumedUrl));
         const deleteButton = trElement.querySelector(".delete-assignment");
         const that = this;
         Logic.addEnterHandler(deleteButton, async () => {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -987,7 +987,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
            This is pending a better solution for favicons from web extensions */
         const assumedUrl = `https://${site.hostname}`;
         trElement.innerHTML = escaped`
-        <img class="icon" src="${assumedUrl}/favicon.ico">
+        <div></div>
         <div title="${site.hostname}" class="truncate-text hostname">
           ${site.hostname}
         </div>
@@ -995,6 +995,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
           class="pop-button-image delete-assignment"
           src="/img/container-delete.svg"
         />`;
+        trElement.querySelector("div").appendChild(Utils.createFavIconElement(assumedUrl));
         const deleteButton = trElement.querySelector(".delete-assignment");
         const that = this;
         Logic.addEnterHandler(deleteButton, async () => {


### PR DESCRIPTION
Fix for #1314

## Fix
![1314bug](https://user-images.githubusercontent.com/3195251/61902095-e76e7e00-aee6-11e9-9ff7-c828a2b28939.jpg)

 
## Steps to test
1. Load new extension
2. Add groovecoder.com or another site with no favicon to a container and select to always use that container.
3.  Click "Edit containers" and select the container you chose (pencil).
4. default favicon should be displayed.