### PR TITLE
Container locking - restrict container to currently assigned domains

### DIFF
--- a/LICENCE.MIT.txt
+++ b/LICENCE.MIT.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Call-Em-All
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ Facebook & Twitter icons CC-Attrib https://fairheadcreative.com.
 - [License](./LICENSE.txt)
 - [Contributing](./CONTRIBUTING.md)
 - [Code Of Conduct](./CODE_OF_CONDUCT.md)
+
+SVG icons `container-lock.svg`, `container-unlock.svg` attributed to https://github.com/mui-org/material-ui
+and covered by the [MIT Licence](./LICENCE.MIT.txt).

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "stylelint-config-standard": "^16.0.0",
     "stylelint-order": "^0.3.0",
     "web-ext": "^2.9.3",
-    "webextensions-jsdom": "^1.1.0"
+    "webextensions-jsdom": "^1.1.1"
   },
   "homepage": "https://github.com/mozilla/multi-account-containers#readme",
   "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "bugs": {
     "url": "https://github.com/mozilla/multi-account-containers/issues"
   },
-  "dependencies": {},
   "devDependencies": {
     "addons-linter": "^1.3.2",
     "ajv": "^6.6.2",

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -593,7 +593,6 @@ span ~ .panel-header-text {
 }
 
 .userContext-wrapper {
-  align-items: center;
   display: flex;
   flex: 1 1;
   transition: background-color 75ms;
@@ -608,6 +607,23 @@ span ~ .panel-header-text {
   block-size: var(--icon-button-size);
   flex: 0 0 var(--icon-button-size);
   margin-inline-start: var(--inline-icon-space-size);
+}
+
+.userContext-name-wrapper {
+  align-self: center;
+  flex: 1;
+}
+
+.container-panel-row .container-lockorunlock {
+  align-items: center;
+  display: flex;
+  flex: 0 0 var(--icon-button-size);
+}
+
+.container-panel-row .container-lockorunlock img {
+  align-self: center;
+  block-size: 20px;
+  flex: 1;
 }
 
 /* .userContext-icon is used natively, Bug 1333811 was raised to fix */
@@ -926,12 +942,24 @@ span ~ .panel-header-text {
 }
 
 /* https://github.com/mozilla/multi-account-containers/issues/847 */
-.container-lockorunlock.container-locked * {
-  filter: invert(0.5) sepia(1) saturate(127) hue-rotate(360deg);
+.container-lockorunlock * {
+  fill: #979797;
+  filter: url('/img/filters.svg#fill');
 }
 
-.container-lockorunlock.container-unlocked * {
-  filter: invert(0.5);
+.container-lockorunlock:hover * {
+  fill: black;
+  filter: url('/img/filters.svg#fill');
+}
+
+.container-lockorunlock.container-locked * {
+  fill: red;
+  filter: url('/img/filters.svg#fill');
+}
+
+.container-lockorunlock.container-locked:hover * {
+  fill: #ba1111;
+  filter: url('/img/filters.svg#fill');
 }
 
 /* Achievement panel elements */

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -925,6 +925,15 @@ span ~ .panel-header-text {
   padding-block-end: 6px;
 }
 
+/* https://github.com/mozilla/multi-account-containers/issues/847 */
+.container-lockorunlock.container-locked * {
+  filter: invert(0.5) sepia(1) saturate(127) hue-rotate(360deg);
+}
+
+.container-lockorunlock.container-unlocked * {
+  filter: invert(0.5);
+}
+
 /* Achievement panel elements */
 .share-ctas {
   padding-block-end: 0.5em;

--- a/src/img/container-lock.svg
+++ b/src/img/container-lock.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Adapted from https://www.materialui.co/icon/lock -->
+
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+  <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/>
+</svg> 

--- a/src/img/container-lock.svg
+++ b/src/img/container-lock.svg
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<!-- Adapted from https://www.materialui.co/icon/lock -->
-
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
   <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/>

--- a/src/img/container-unlock.svg
+++ b/src/img/container-unlock.svg
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<!-- Adapted from https://www.materialui.co/icon/lock-open -->
-
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
   <path d="M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h1.9c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm0 12H6V10h12v10z"/>

--- a/src/img/container-unlock.svg
+++ b/src/img/container-unlock.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Adapted from https://www.materialui.co/icon/lock-open -->
+
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+  <path d="M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h1.9c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm0 12H6V10h12v10z"/>
+</svg> 

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -128,7 +128,7 @@ const backgroundLogic = {
     if (!("userContextId" in options)) {
       return Promise.reject("lockOrUnlockContainer must be called with userContextId argument.");
     }
-  
+
     const cookieStoreId = this.cookieStoreId(options.userContextId);
     const containerState = await identityState.storageArea.get(cookieStoreId);
     if (options.isLocked) {
@@ -138,7 +138,7 @@ const backgroundLogic = {
     }
     return await identityState.storageArea.set(cookieStoreId, containerState);
   },
-  
+
 
   async moveTabsToWindow(options) {
     const requiredArguments = ["cookieStoreId", "windowId"];
@@ -251,6 +251,15 @@ const backgroundLogic = {
       return;
     });
     await Promise.all(identitiesPromise);
+
+    // Add number of assignments for each identity
+    const numbersOfAssignments = await assignManager.storageArea.getNumbersOfAssignments();
+    Object.keys(numbersOfAssignments).forEach(userContextId => {
+      const cookieStoreId = backgroundLogic.cookieStoreId(userContextId);
+      const identity = identitiesOutput[cookieStoreId];
+      if (identity) { identity.numberOfAssignments = numbersOfAssignments[userContextId]; }
+    });
+
     return identitiesOutput;
   },
 

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -123,6 +123,22 @@ const backgroundLogic = {
     }
   },
 
+  // https://github.com/mozilla/multi-account-containers/issues/847
+  async lockOrUnlockContainer(options) {
+    if (!("userContextId" in options)) {
+      return Promise.reject("lockOrUnlockContainer must be called with userContextId argument.");
+    }
+  
+    const cookieStoreId = this.cookieStoreId(options.userContextId);
+    const containerState = await identityState.storageArea.get(cookieStoreId);
+    if (options.isLocked) {
+      containerState.isLocked = "locked";
+    } else {
+      delete containerState.isLocked;
+    }
+    return await identityState.storageArea.set(cookieStoreId, containerState);
+  },
+  
 
   async moveTabsToWindow(options) {
     const requiredArguments = ["cookieStoreId", "windowId"];
@@ -229,7 +245,9 @@ const backgroundLogic = {
         hasHiddenTabs: !!containerState.hiddenTabs.length,
         hasOpenTabs: !!openTabs.length,
         numberOfHiddenTabs: containerState.hiddenTabs.length,
-        numberOfOpenTabs: openTabs.length
+        numberOfOpenTabs: openTabs.length,
+        // https://github.com/mozilla/multi-account-containers/issues/847
+        isLocked: !!containerState.isLocked
       };
       return;
     });

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -246,7 +246,6 @@ const backgroundLogic = {
         hasOpenTabs: !!openTabs.length,
         numberOfHiddenTabs: containerState.hiddenTabs.length,
         numberOfOpenTabs: openTabs.length,
-        // https://github.com/mozilla/multi-account-containers/issues/847
         isLocked: !!containerState.isLocked
       };
       return;

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -20,7 +20,6 @@ const messageHandler = {
         response = backgroundLogic.createOrUpdateContainer(m.message);
         break;
       case "lockOrUnlockContainer":
-        // https://github.com/mozilla/multi-account-containers/issues/847
         response = backgroundLogic.lockOrUnlockContainer(m.message);
         break;
       case "neverAsk":

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -19,6 +19,10 @@ const messageHandler = {
       case "createOrUpdateContainer":
         response = backgroundLogic.createOrUpdateContainer(m.message);
         break;
+      case "lockOrUnlockContainer":
+        // https://github.com/mozilla/multi-account-containers/issues/847
+        response = backgroundLogic.lockOrUnlockContainer(m.message);
+        break;
       case "neverAsk":
         assignManager._neverAsk(m);
         break;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -4,7 +4,6 @@
 
 const CONTAINER_HIDE_SRC = "/img/container-hide.svg";
 const CONTAINER_UNHIDE_SRC = "/img/container-unhide.svg";
-// https://github.com/mozilla/multi-account-containers/issues/847
 const CONTAINER_LOCKED_SRC = "/img/container-lock.svg";
 const CONTAINER_UNLOCKED_SRC = "/img/container-unlock.svg";
 
@@ -255,7 +254,6 @@ const Logic = {
         identity.hasHiddenTabs = stateObject.hasHiddenTabs;
         identity.numberOfHiddenTabs = stateObject.numberOfHiddenTabs;
         identity.numberOfOpenTabs = stateObject.numberOfOpenTabs;
-        // https://github.com/mozilla/multi-account-containers/issues/847
         identity.isLocked = stateObject.isLocked;
       }
       return identity;
@@ -1041,7 +1039,6 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       lockElement.classList.add("container-info-tab-row", "clickable", "container-lockorunlock", lockOrUnlockClass);
       tableElement.appendChild(lockElement);
       
-      const that = this;
       Logic.addEnterHandler(lockElement, async () => {
         try {
           await browser.runtime.sendMessage({
@@ -1051,12 +1048,12 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
               isLocked: !isLocked
             }
           });
-          that.showAssignedContainers(assignments, !isLocked);
+          this.showAssignedContainers(assignments, !isLocked);
         } catch (e) {
           throw new Error("Failed to lock/unlock. ", e.message);
         }
       });
-      /* Container locking: https://github.com/mozilla/multi-account-containers/issues/847 */
+      /* Container locking end */
       
       /* Assignment list */
       assignmentKeys.forEach((siteKey) => {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -370,6 +370,16 @@ const Logic = {
       value
     });
   },
+  
+  lockOrUnlockContainer(userContextId, isLocked) {
+    return browser.runtime.sendMessage({
+      method: "lockOrUnlockContainer",
+      message: {
+        userContextId: userContextId,
+        isLocked: !!isLocked
+      }
+    });
+  },
 
   generateIdentityName() {
     const defaultName = "Container #";
@@ -1041,16 +1051,10 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       
       Logic.addEnterHandler(lockElement, async () => {
         try {
-          await browser.runtime.sendMessage({
-            method: "lockOrUnlockContainer",
-            message: {
-              userContextId: Logic.currentUserContextId(),
-              isLocked: !isLocked
-            }
-          });
+          await Logic.lockOrUnlockContainer(Logic.currentUserContextId(), !isLocked);
           this.showAssignedContainers(assignments, !isLocked);
         } catch (e) {
-          throw new Error("Failed to lock/unlock. ", e.message);
+          throw new Error("Failed to lock/unlock container: " + e.message);
         }
       });
       /* Container locking end */

--- a/test/features/lock.test.js
+++ b/test/features/lock.test.js
@@ -1,0 +1,54 @@
+// https://github.com/mozilla/multi-account-containers/issues/847
+describe("Lock Feature", () => {
+  const activeTab = {
+    id: 1,
+    cookieStoreId: "firefox-container-1",
+    url: "http://example.com",
+    index: 0
+  };
+  beforeEach(async () => {
+    await helper.browser.initializeWithTab(activeTab);
+  });
+
+  describe("click the 'Always open in' checkbox in the popup", () => {
+    beforeEach(async () => {
+      // popup click to set assignment for activeTab.url
+      await helper.popup.clickElementById("container-page-assigned");
+    });
+    
+    describe("open different URL in same tab", () => {
+      const differentURL = "http://example2.com";
+      beforeEach(async () => {
+        await helper.browser.updateTab(activeTab, {
+          url: differentURL,
+          resetHistory: true
+        });
+      });
+
+      it("should not open a new tab", () => {
+        background.browser.tabs.create.should.not.have.been.called;
+      });
+    
+      describe("lock the container", () => {
+        beforeEach(async () => {
+          await helper.popup.setContainerIsLocked(activeTab.cookieStoreId, true);
+        });
+    
+        describe("open different URL in same tab", () => {
+          beforeEach(async () => {
+            await helper.browser.updateTab(activeTab, {
+              url: differentURL,
+              resetHistory: true
+            });
+          });
+
+          it("should open a new tab in the default container", () => {
+            background.browser.tabs.create.should.have.been.calledWith({
+              url: differentURL
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/features/lock.test.js
+++ b/test/features/lock.test.js
@@ -4,7 +4,8 @@ describe("Lock Feature", () => {
     id: 1,
     cookieStoreId: "firefox-container-1",
     url: "http://example.com",
-    index: 0
+    index: 0,
+    active: true
   };
   beforeEach(async () => {
     await helper.browser.initializeWithTab(activeTab);
@@ -19,10 +20,7 @@ describe("Lock Feature", () => {
     describe("open different URL in same tab", () => {
       const differentURL = "http://example2.com";
       beforeEach(async () => {
-        await helper.browser.updateTab(activeTab, {
-          url: differentURL,
-          resetHistory: true
-        });
+        await helper.browser.browseToURL(activeTab.id, differentURL);
       });
 
       it("should not open a new tab", () => {
@@ -36,16 +34,17 @@ describe("Lock Feature", () => {
     
         describe("open different URL in same tab", () => {
           beforeEach(async () => {
-            await helper.browser.updateTab(activeTab, {
-              url: differentURL,
-              resetHistory: true
-            });
+            await helper.browser.browseToURL(activeTab.id, differentURL);
           });
 
           it("should open a new tab in the default container", () => {
-            background.browser.tabs.create.should.have.been.calledWith({
-              url: differentURL
-            });
+            background.browser.tabs.create.should.have.been.calledWith(sinon.match({
+              url: differentURL,
+              cookieStoreId: "firefox-default",
+              openerTabId: activeTab.id,
+              index: activeTab.index + 1,
+              active: activeTab.active
+            }));
           });
         });
       });

--- a/test/features/lock.test.js
+++ b/test/features/lock.test.js
@@ -1,14 +1,14 @@
 // https://github.com/mozilla/multi-account-containers/issues/847
 describe("Lock Feature", () => {
-  const activeTab = {
-    id: 1,
-    cookieStoreId: "firefox-container-1",
-    url: "http://example.com",
-    index: 0,
-    active: true
-  };
+  const url1 = "http://example.com";
+  const url2 = "http://example2.com";
+
+  let activeTab;
   beforeEach(async () => {
-    await helper.browser.initializeWithTab(activeTab);
+    activeTab = await helper.browser.initializeWithTab({
+      cookieStoreId: "firefox-container-1",
+      url: url1
+    });
   });
 
   describe("click the 'Always open in' checkbox in the popup", () => {
@@ -18,9 +18,8 @@ describe("Lock Feature", () => {
     });
     
     describe("open different URL in same tab", () => {
-      const differentURL = "http://example2.com";
       beforeEach(async () => {
-        await helper.browser.browseToURL(activeTab.id, differentURL);
+        await helper.browser.browseToURL(activeTab.id, url2);
       });
 
       it("should not open a new tab", () => {
@@ -32,19 +31,30 @@ describe("Lock Feature", () => {
           await helper.popup.setContainerIsLocked(activeTab.cookieStoreId, true);
         });
     
-        describe("open different URL in same tab", () => {
+        describe("wait 2 seconds, then open different URL in same tab", () => {
           beforeEach(async () => {
-            await helper.browser.browseToURL(activeTab.id, differentURL);
+            // Note: must wait 2 seconds, because of code in messageHandler that assumes
+            // a newly-created tab is not 'genuine' until 2 seconds have elapsed since
+            // its creation.
+            // Unfortunately, this test runner recreates the tab at every single 'beforeEach',
+            // so messageHandler thinks the tab is not genuine and tries to remove it,
+            // meaning the below tests will (incorrectly) fail.
+            await global.sleep(2500);
+            await helper.browser.browseToURL(activeTab.id, url2);
           });
 
           it("should open a new tab in the default container", () => {
             background.browser.tabs.create.should.have.been.calledWith(sinon.match({
-              url: differentURL,
+              url: url2,
               cookieStoreId: "firefox-default",
               openerTabId: activeTab.id,
               index: activeTab.index + 1,
               active: activeTab.active
             }));
+          });
+          
+          it("should not remove the original tab", () => {
+            background.browser.tabs.remove.should.not.have.been.called;
           });
         });
       });

--- a/test/helper.js
+++ b/test/helper.js
@@ -53,21 +53,9 @@ module.exports = {
     
     // https://github.com/mozilla/multi-account-containers/issues/847
     async setContainerIsLocked(cookieStoreId, isLocked) {
-      const identityStateKey = this.getIdentityStateContainerStoreKey(cookieStoreId);
-      const identityState = await background.browser.storage.local.get([identityStateKey]) || {};
-      if (isLocked) {
-        identityState.isLocked = "locked";
-      } else {
-        delete identityState.isLocked;
-      }
-      // Must have valid 'hiddenTabs', otherwise backgroundLogic.showTabs() throws error
-      if (!identityState.hiddenTabs) { identityState.hiddenTabs = []; }
-      await background.browser.storage.local.set({[identityStateKey]: identityState});
-    },
-    
-    getIdentityStateContainerStoreKey(cookieStoreId) {
-      const storagePrefix = "identitiesState@@_";
-      return `${storagePrefix}${cookieStoreId}`;      
+      const Logic = popup.dom.window.eval("Logic");
+      const userContextId = Logic.userContextId(cookieStoreId);
+      await Logic.lockOrUnlockContainer(userContextId, isLocked);
     }
   }
 };

--- a/test/helper.js
+++ b/test/helper.js
@@ -30,18 +30,16 @@ module.exports = {
     async openNewTab(tab, options = {}) {
       return background.browser.tabs._create(tab, options);
     },
-
+    
     // https://github.com/mozilla/multi-account-containers/issues/847
-    async updateTab(tab, options = {}) {
-      const updatedTab = {};
-      for (const key in tab) {
-        updatedTab[key] = tab[key];
-      }
-      for (const key in options) {
-        updatedTab[key] = options[key];
-      }
-      return this.openNewTab(updatedTab);
-    },
+    async browseToURL(tabId, url) {
+      const [promise] = background.browser.webRequest.onBeforeRequest.addListener.yield({
+        frameId: 0,
+        tabId: tabId,
+        url: url
+      });
+      return promise;
+    }
   },
 
   popup: {

--- a/test/helper.js
+++ b/test/helper.js
@@ -11,6 +11,8 @@ module.exports = {
           }
         },
         popup: {
+          // Required to access variables, because nyc messes up 'eval'
+          script: "function evalScript(v) { return eval(v); }",
           jsdom: {
             beforeParse(window) {
               window.browser.storage.local.set({
@@ -31,7 +33,6 @@ module.exports = {
       return background.browser.tabs._create(tab, options);
     },
     
-    // https://github.com/mozilla/multi-account-containers/issues/847
     async browseToURL(tabId, url) {
       const [promise] = background.browser.webRequest.onBeforeRequest.addListener.yield({
         frameId: 0,
@@ -53,7 +54,7 @@ module.exports = {
     
     // https://github.com/mozilla/multi-account-containers/issues/847
     async setContainerIsLocked(cookieStoreId, isLocked) {
-      const Logic = popup.dom.window.eval("Logic");
+      const Logic = popup.window.evalScript("Logic");
       const userContextId = Logic.userContextId(cookieStoreId);
       await Logic.lockOrUnlockContainer(userContextId, isLocked);
     }

--- a/test/setup.js
+++ b/test/setup.js
@@ -16,6 +16,9 @@ global.nextTick = () => {
     });
   });
 };
+global.sleep = (delay) => {
+  return new Promise((resolve) => { setTimeout(resolve, delay); });
+};
 
 global.helper = require("./helper");
 


### PR DESCRIPTION
#847 Provides functionality for locking a container. Once locked, any requests for domains that are not in the assignments list for that container will open in a new tab.

Unit tests included.

<img width="305" alt="Container Unlocked" src="https://user-images.githubusercontent.com/439593/61718099-2cb17500-ad5a-11e9-9221-e0269a62b72d.png">

<img width="304" alt="Container Locked" src="https://user-images.githubusercontent.com/439593/61718110-3044fc00-ad5a-11e9-9af8-77df3035e8c7.png">

(This pull request is identical to the earlier one I submitted, but that one got cancelled because I moved the checkins to a separate branch on my fork.)