### PR TITLE
Bugfix: incorrect scrollbars/spacing if edit container with many assignments

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -23,6 +23,15 @@ body {
   max-inline-size: 300px;
 }
 
+/**
+ Bugfix: incorrect scrollbars/spacing when editing container with many assignments
+ https://github.com/mozilla/multi-account-containers/issues/948
+ */
+html,
+body {
+  block-size: 100%;
+}
+
 :root {
   --primary-action-color: #248aeb;
   --title-text-color: #000;
@@ -783,8 +792,20 @@ span ~ .panel-header-text {
   padding-inline-start: 16px;
 }
 
+/**
+ Bugfix: incorrect scrollbars/spacing when editing container with many assignments
+ https://github.com/mozilla/multi-account-containers/issues/948
+ */
+.edit-container-panel .columns {
+  overflow: hidden;
+}
+
 #edit-sites-assigned {
-  flex: 1;
+  /**
+   Bugfix: incorrect scrollbars/spacing when editing container with many assignments
+   https://github.com/mozilla/multi-account-containers/issues/948
+   */
+  flex: 1000;
 }
 
 #edit-sites-assigned h3 {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -23,13 +23,9 @@ body {
   max-inline-size: 300px;
 }
 
-/**
- Bugfix: incorrect scrollbars/spacing when editing container with many assignments
- https://github.com/mozilla/multi-account-containers/issues/948
- */
 html,
 body {
-  block-size: 100%;
+  block-size: 100%; /* Bugfix: issue 948 */
 }
 
 :root {
@@ -792,20 +788,12 @@ span ~ .panel-header-text {
   padding-inline-start: 16px;
 }
 
-/**
- Bugfix: incorrect scrollbars/spacing when editing container with many assignments
- https://github.com/mozilla/multi-account-containers/issues/948
- */
 .edit-container-panel .columns {
-  overflow: hidden;
+  overflow: hidden; /* Bugfix: issue 948 */
 }
 
 #edit-sites-assigned {
-  /**
-   Bugfix: incorrect scrollbars/spacing when editing container with many assignments
-   https://github.com/mozilla/multi-account-containers/issues/948
-   */
-  flex: 1000;
+  flex: 1000; /* Bugfix: issue 948 */
 }
 
 #edit-sites-assigned h3 {


### PR DESCRIPTION
#948 Fixes big empty gap above assignments list and multiple scrollbars, when editing container with many assignments.