### PR TITLE
Fixed #766 — Popup display expands to fit overflow menu

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -47,7 +47,7 @@ body {
   --icon-button-size: calc(calc(var(--block-line-separation-size) * 2) + 1.66rem); /* 20px */
   --column-panel-inline-size: calc(var(--overflow-size) + 268px);
   --inactive-opacity: 0.3;
-  --overflow-size: 0;
+  --overflow-size: 0px;
   --icon-fit: 8;
 }
 

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -47,7 +47,7 @@ body {
   --icon-button-size: calc(calc(var(--block-line-separation-size) * 2) + 1.66rem); /* 20px */
   --column-panel-inline-size: calc(var(--overflow-size) + 268px);
   --inactive-opacity: 0.3;
-  --overflow-size: 0px;
+  --overflow-size: 0;
   --icon-fit: 8;
 }
 

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -19,8 +19,8 @@ html {
 
 body {
   font-family: Roboto, Noto, "San Francisco", Ubuntu, "Segoe UI", "Fira Sans", message-box, Arial, sans-serif;
-  inline-size: 300px;
-  max-inline-size: 300px;
+  inline-size: calc(var(--overflow-size) + 300px);
+  max-inline-size: calc(var(--overflow-size) + 300px);
 }
 
 :root {
@@ -45,8 +45,10 @@ body {
   --small-text-size: 0.833rem; /* 10px */
   --small-radius: 3px;
   --icon-button-size: calc(calc(var(--block-line-separation-size) * 2) + 1.66rem); /* 20px */
-  --column-panel-inline-size: 268px;
+  --column-panel-inline-size: calc(var(--overflow-size) + 268px);
   --inactive-opacity: 0.3;
+  --overflow-size: 0px;
+  --icon-fit: 8;
 }
 
 @media (min-resolution: 1dppx) {
@@ -577,7 +579,7 @@ span ~ .panel-header-text {
 }
 
 .edit-containers-panel .userContext-wrapper {
-  max-inline-size: 204px;
+  max-inline-size: calc(var(--overflow-size) + 204px);
 }
 
 .disable-edit-containers {
@@ -822,7 +824,7 @@ span ~ .panel-header-text {
   align-items: center;
   block-size: 29px;
   display: flex;
-  flex: 0 0 calc(100% / 8);
+  flex: 0 0 calc(100% / var(--icon-fit));
 }
 
 .radio-choice > .radio-container > label {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -19,8 +19,8 @@ html {
 
 body {
   font-family: Roboto, Noto, "San Francisco", Ubuntu, "Segoe UI", "Fira Sans", message-box, Arial, sans-serif;
-  inline-size: calc(var(--overflow-size) + 300px);
-  max-inline-size: calc(var(--overflow-size) + 300px);
+  inline-size: calc(var(--overflow-size) + 299px);
+  max-inline-size: calc(var(--overflow-size) + 299px);
 }
 
 :root {
@@ -45,9 +45,9 @@ body {
   --small-text-size: 0.833rem; /* 10px */
   --small-radius: 3px;
   --icon-button-size: calc(calc(var(--block-line-separation-size) * 2) + 1.66rem); /* 20px */
-  --column-panel-inline-size: calc(var(--overflow-size) + 268px);
+  --column-panel-inline-size: calc(var(--overflow-size) + 267px);
   --inactive-opacity: 0.3;
-  --overflow-size: 0px;
+  --overflow-size: 1px;
   --icon-fit: 8;
 }
 
@@ -579,7 +579,7 @@ span ~ .panel-header-text {
 }
 
 .edit-containers-panel .userContext-wrapper {
-  max-inline-size: calc(var(--overflow-size) + 204px);
+  max-inline-size: calc(var(--overflow-size) + 203px);
 }
 
 .disable-edit-containers {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -292,11 +292,11 @@ const Logic = {
     document.querySelector(this.getPanelSelector(this._panels[panel])).classList.remove("hide");
     window.setTimeout(function () {
       //sometimes this executes before the window is there and window.innerWidth returns undefined
-      const width = window.innerWidth;
-      if (width > 300) {
+      const difference = window.innerWidth - document.body.offsetWidth
+      if (difference > 2) {
         //if popup is in the overflow menu, window will be larger than 300px
         const root = document.documentElement;
-        root.style.setProperty("--overflow-size", "125px");
+        root.style.setProperty("--overflow-size", difference + "px");
         root.style.setProperty("--icon-fit", "12");
       }
     }, 200);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -290,16 +290,6 @@ const Logic = {
       }
     });
     document.querySelector(this.getPanelSelector(this._panels[panel])).classList.remove("hide");
-    window.setTimeout(function () {
-      //sometimes this executes before the window is there and window.innerWidth returns undefined
-      const difference = window.innerWidth - document.body.offsetWidth;
-      if (difference > 2) {
-        //if popup is in the overflow menu, window will be larger than 300px
-        const root = document.documentElement;
-        root.style.setProperty("--overflow-size", difference + "px");
-        root.style.setProperty("--icon-fit", "12");
-      }
-    }, 200);
   },
 
   showPreviousPanel() {
@@ -1154,3 +1144,14 @@ Logic.registerPanel(P_CONTAINERS_ACHIEVEMENT, {
 });
 
 Logic.init();
+
+window.addEventListener("resize", function () {
+  //for overflow menu
+  const difference = window.innerWidth - document.body.offsetWidth;
+  if (difference > 2) {
+    //if popup is in the overflow menu, window will be larger than 300px
+    const root = document.documentElement;
+    root.style.setProperty("--overflow-size", difference + "px");
+    root.style.setProperty("--icon-fit", "12");
+  }
+});

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -272,7 +272,6 @@ const Logic = {
       throw new Error("Something really bad happened. Unknown panel: " + panel);
     }
 
-
     this._previousPanel = this._currentPanel;
     this._currentPanel = panel;
 
@@ -293,12 +292,12 @@ const Logic = {
     document.querySelector(this.getPanelSelector(this._panels[panel])).classList.remove("hide");
     window.setTimeout(function () {
       //sometimes this executes before the window is there and window.innerWidth returns undefined
-      var width = window.innerWidth;
+      const width = window.innerWidth;
       if (width > 300) {
         //if popup is in the overflow menu, window will be larger than 300px
-        var root = document.documentElement;
-        root.style.setProperty('--overflow-size', "125px");
-        root.style.setProperty('--icon-fit', "12");
+        const root = document.documentElement;
+        root.style.setProperty("--overflow-size", "125px");
+        root.style.setProperty("--icon-fit", "12");
       }
     }, 200);
   },

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -292,7 +292,7 @@ const Logic = {
     document.querySelector(this.getPanelSelector(this._panels[panel])).classList.remove("hide");
     window.setTimeout(function () {
       //sometimes this executes before the window is there and window.innerWidth returns undefined
-      const difference = window.innerWidth - document.body.offsetWidth
+      const difference = window.innerWidth - document.body.offsetWidth;
       if (difference > 2) {
         //if popup is in the overflow menu, window will be larger than 300px
         const root = document.documentElement;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -272,6 +272,12 @@ const Logic = {
       throw new Error("Something really bad happened. Unknown panel: " + panel);
     }
 
+    if (window.innerWidth > 300) {
+      //if popup is in the overflow menu, window will be larger than 300px
+      var root = document.documentElement;
+      root.style.setProperty('--overflow-size', "125px");
+      root.style.setProperty('--icon-fit', "12");
+    }
     this._previousPanel = this._currentPanel;
     this._currentPanel = panel;
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -272,12 +272,7 @@ const Logic = {
       throw new Error("Something really bad happened. Unknown panel: " + panel);
     }
 
-    if (window.innerWidth > 300) {
-      //if popup is in the overflow menu, window will be larger than 300px
-      var root = document.documentElement;
-      root.style.setProperty('--overflow-size', "125px");
-      root.style.setProperty('--icon-fit', "12");
-    }
+
     this._previousPanel = this._currentPanel;
     this._currentPanel = panel;
 
@@ -296,6 +291,16 @@ const Logic = {
       }
     });
     document.querySelector(this.getPanelSelector(this._panels[panel])).classList.remove("hide");
+    window.setTimeout(function () {
+      //sometimes this executes before the window is there and window.innerWidth returns undefined
+      var width = window.innerWidth;
+      if (width > 300) {
+        //if popup is in the overflow menu, window will be larger than 300px
+        var root = document.documentElement;
+        root.style.setProperty('--overflow-size', "125px");
+        root.style.setProperty('--icon-fit', "12");
+      }
+    }, 200);
   },
 
   showPreviousPanel() {


### PR DESCRIPTION
## Testing Steps
1. Put MAC addon into the overflow menu (in customize), or shrink Firefox to force it into overflow.
2. Open MAC and click through.
## Screen Caps
Before:
![Screenshot from 2019-08-27 10-17-34](https://user-images.githubusercontent.com/3195251/63785088-61fb3680-c8b5-11e9-8b34-5cddec562239.png)
After:
![Screenshot from 2019-08-27 10-16-40](https://user-images.githubusercontent.com/3195251/63785089-6293cd00-c8b5-11e9-9bd1-57ff98adef99.png)
Full click through for no overflow and then overflow:
![Peek 2019-08-26 17-09](https://user-images.githubusercontent.com/3195251/63785117-6f182580-c8b5-11e9-8c37-bb185b8af910.gif)

