### PR TITLE
#1375 - Correct colors on confirmation page

### DIFF
--- a/src/css/confirm-page.css
+++ b/src/css/confirm-page.css
@@ -47,7 +47,7 @@ html {
 }
 
 #redirect-url {
-  background: #efefef;
+  background: #efedf0; /* Grey 20 */
   border-radius: 2px;
   line-height: 1.5;
   padding-block-end: 0.5rem;
@@ -55,6 +55,14 @@ html {
   padding-inline-end: 0.5rem;
   padding-inline-start: 0.5rem;
 }
+
+/* stylelint-disable media-feature-name-no-unknown */
+@media (prefers-color-scheme: dark) {
+  #redirect-url {
+    background: #38383d; /* Grey 70 */
+  }
+}
+/* stylelint-enable */
 
 #redirect-url img {
   block-size: 16px;


### PR DESCRIPTION
Firefox's dark mode sets the background of the confirmation page to Grey 80 (`#2a2a2e`). As pointed out in [this comment](https://github.com/mozilla/multi-account-containers/issues/1375#issuecomment-500107995), the `#redirect-url` background remains `#efefef`, making the redirect url unreadable. 

This patch corrects the background color in dark mode. It also slightly changes the color in light mode to make it consistent with the [Photon colors](https://design.firefox.com/photon/visuals/color.html).