### PR TITLE
refactor badge.displayBrowserActionBadge to be used in messageHandler fixes #973 & refactoring pop.js to fixes #1513

### DIFF
--- a/src/js/background/badge.js
+++ b/src/js/background/badge.js
@@ -10,16 +10,29 @@ const badge = {
     browser.browserAction.setTitle({ tabId, title: "Containers disabled in Private Browsing Mode" });
   },
 
-  async displayBrowserActionBadge() {
+  async displayBrowserActionBadge(action) { 
     const extensionInfo = await backgroundLogic.getExtensionInfo();
-    const storage = await browser.storage.local.get({browserActionBadgesClicked: []});
-
-    if (MAJOR_VERSIONS.indexOf(extensionInfo.version) > -1 &&
-        storage.browserActionBadgesClicked.indexOf(extensionInfo.version) < 0) {
-      browser.browserAction.setBadgeBackgroundColor({color: "rgba(0,217,0,255)"});
-      browser.browserAction.setBadgeText({text: "NEW"});
+      function changeBadgeColorText(color, text){
+        browser.browserAction.setBadgeBackgroundColor({color: color});
+        browser.browserAction.setBadgeText({text: text});
+      }
+    if(action==="remove"){    
+      const ActionBadgesClickedStorage = await browser.storage.local.get({browserActionBadgesClicked: []});
+      if (MAJOR_VERSIONS.indexOf(extensionInfo.version) > -1 &&
+          ActionBadgesClickedStorage.browserActionBadgesClicked.indexOf(extensionInfo.version) < 0) {
+          changeBadgeColorText("rgba(0,217,0,255)", "NEW")
+      }
+    }
+    else if (action==="showAchievement"){
+      const achievementsStorage = await browser.storage.local.get({achievements: []});
+      achievementsStorage.achievements.push({"name": "manyContainersOpened", "done": false});
+      // use set and spread to create a unique array
+      const achievements = [...new Set(achievementsStorage.achievements)];
+      browser.storage.local.set({achievements});
+      changeBadgeColorText("rgba(0,217,0,255)", "NEW");
     }
   }
+    
 };
 
 badge.init();

--- a/src/js/background/badge.js
+++ b/src/js/background/badge.js
@@ -12,18 +12,18 @@ const badge = {
 
   async displayBrowserActionBadge(action) { 
     const extensionInfo = await backgroundLogic.getExtensionInfo();
-      function changeBadgeColorText(color, text){
-        browser.browserAction.setBadgeBackgroundColor({color: color});
-        browser.browserAction.setBadgeText({text: text});
-      }
-    if(action==="remove"){    
+    function changeBadgeColorText(color, text){
+      browser.browserAction.setBadgeBackgroundColor({color: color});
+      browser.browserAction.setBadgeText({text: text});
+    }
+    if(action==="remove") {    
       const ActionBadgesClickedStorage = await browser.storage.local.get({browserActionBadgesClicked: []});
       if (MAJOR_VERSIONS.indexOf(extensionInfo.version) > -1 &&
           ActionBadgesClickedStorage.browserActionBadgesClicked.indexOf(extensionInfo.version) < 0) {
-          changeBadgeColorText("rgba(0,217,0,255)", "NEW")
+        changeBadgeColorText("rgba(0,217,0,255)", "NEW");
       }
     }
-    else if (action==="showAchievement"){
+    else if (action==="showAchievement") {
       const achievementsStorage = await browser.storage.local.get({achievements: []});
       achievementsStorage.achievements.push({"name": "manyContainersOpened", "done": false});
       // use set and spread to create a unique array

--- a/src/js/background/badge.js
+++ b/src/js/background/badge.js
@@ -1,8 +1,8 @@
 const MAJOR_VERSIONS = ["2.3.0", "2.4.0"];
 const badge = {
   async init() {
-    const currentWindow = await browser.windows.getCurrent();
-    this.displayBrowserActionBadge(currentWindow.incognito);
+    const showVersionIndicator = await browser.windows.getCurrent();
+    this.displayBrowserActionBadge(showVersionIndicator);
   },
 
   disableAddon(tabId) {
@@ -16,7 +16,7 @@ const badge = {
       browser.browserAction.setBadgeBackgroundColor({color: color});
       browser.browserAction.setBadgeText({text: text});
     }
-    if(action==="remove") {    
+    if(action==="showVersionIndicator") {    
       const ActionBadgesClickedStorage = await browser.storage.local.get({browserActionBadgesClicked: []});
       if (MAJOR_VERSIONS.indexOf(extensionInfo.version) > -1 &&
           ActionBadgesClickedStorage.browserActionBadgesClicked.indexOf(extensionInfo.version) < 0) {

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -171,13 +171,7 @@ const messageHandler = {
 
     // When the user opens their _ tab, give them the achievement
     if (countOfContainerTabsOpened === 100) {
-      const storage = await browser.storage.local.get({achievements: []});
-      storage.achievements.push({"name": "manyContainersOpened", "done": false});
-      // use set and spread to create a unique array
-      const achievements = [...new Set(storage.achievements)];
-      browser.storage.local.set({achievements});
-      browser.browserAction.setBadgeBackgroundColor({color: "rgba(0,217,0,255)"});
-      browser.browserAction.setBadgeText({text: "NEW"});
+      badge.displayBrowserActionBadge("showAchievement");      
     }
   },
 
@@ -187,7 +181,7 @@ const messageHandler = {
     // https://bugzil.la/1314674
     // https://github.com/mozilla/testpilot-containers/issues/608
     // ... so re-call displayBrowserActionBadge on window changes
-    badge.displayBrowserActionBadge();
+    badge.displayBrowserActionBadge("remove");
     browser.tabs.query({active: true, windowId}).then((tabs) => {
       if (tabs && tabs[0]) {
         assignManager.calculateContextMenu(tabs[0]);

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -177,11 +177,6 @@ const messageHandler = {
 
   async onFocusChangedCallback(windowId) {
     assignManager.removeContextMenu();
-    // browserAction loses background color in new windows ...
-    // https://bugzil.la/1314674
-    // https://github.com/mozilla/testpilot-containers/issues/608
-    // ... so re-call displayBrowserActionBadge on window changes
-    badge.displayBrowserActionBadge("remove");
     browser.tabs.query({active: true, windowId}).then((tabs) => {
       if (tabs && tabs[0]) {
         assignManager.calculateContextMenu(tabs[0]);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -79,7 +79,7 @@ const Logic = {
   async init() {
     // Remove browserAction "upgraded" badge when opening panel
     this.clearBrowserActionBadge();
-
+    
     // Retrieve the list of identities.
     const identitiesPromise = this.refreshIdentities();
 
@@ -159,7 +159,7 @@ const Logic = {
     });
   },
 
-  async clearBrowserActionBadge() {
+ async clearBrowserActionBadge() {
     const extensionInfo = await getExtensionInfo();
     const storage = await browser.storage.local.get({browserActionBadgesClicked: []});
     browser.browserAction.setBadgeBackgroundColor({color: null});

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -613,7 +613,7 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       //using DOMParser to modify innerHTML 
       const htmlText = escaped`<span class="page-title truncate-text">${currentTab.title}</span>`;
       const parser =  new DOMParser();
-      const parsed = parser.parseFromString("htmlText", "text/html");
+      const parsed = parser.parseFromString(htmlText, "text/html");
       const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
         currentPage.appendChild(tag);
@@ -657,7 +657,7 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
         </div>
         <div class="container-name truncate-text"></div>`;
       const parser = new DOMParser();
-      const parsed = parser.parseFromString("htmlText", "text/html");
+      const parsed = parser.parseFromString(htmlText, "text/html");
       const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
         context.appendChild(tag);
@@ -822,7 +822,7 @@ Logic.registerPanel(P_CONTAINER_INFO, {
         <td></td>
         <td class="container-info-tab-title truncate-text" title="${tab.url}" ><div class="container-tab-title">${tab.title}</div></td>`;
       const parser = new DOMParser();
-      const parsed = parser.parseFromString("htmlText", "text/html");
+      const parsed = parser.parseFromString(htmlText, "text/html");
       const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
         tr.appendChild(tag);
@@ -910,7 +910,7 @@ Logic.registerPanel(P_CONTAINERS_EDIT, {
           />
         </td>`;
       const parser = new DOMParser();
-      const parsed = parser.parseFromString("htmlText", "text/html");
+      const parsed = parser.parseFromString(htmlText, "text/html");
       const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
         tr.appendChild(tag);
@@ -1025,7 +1025,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
           src="/img/container-delete.svg"
         />`;
         const parser = new DOMParser();
-        const parsed = parser.parseFromString("htmlText", "text/html");
+        const parsed = parser.parseFromString(htmlText, "text/html");
         const tags = parsed.getElementsByTagName("body");
         for (const tag of tags) {
           trElement.appendChild(tag);
@@ -1062,7 +1062,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       // eslint-disable-next-line no-unsanitized/property     
       const htmlText = colorRadioTemplate(containerColor);
       const parser = new DOMParser();
-      const parsed = parser.parseFromString("htmlText", "text/html");
+      const parsed = parser.parseFromString(htmlText, "text/html");
       const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
         templateInstance.appendChild(tag);
@@ -1083,7 +1083,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       // eslint-disable-next-line no-unsanitized/property
       const htmlText= iconRadioTemplate(containerIcon);
       const parser = new DOMParser();
-      const parsed = parser.parseFromString("htmlText", "text/html");
+      const parsed = parser.parseFromString(htmlText, "text/html");
       const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
         templateInstance.appendChild(tag);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -159,7 +159,7 @@ const Logic = {
     });
   },
 
- async clearBrowserActionBadge() {
+  async clearBrowserActionBadge() {
     const extensionInfo = await getExtensionInfo();
     const storage = await browser.storage.local.get({browserActionBadgesClicked: []});
     browser.browserAction.setBadgeBackgroundColor({color: null});
@@ -613,10 +613,10 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       //using DOMParser to modify innerHTML 
       const htmlText = escaped`<span class="page-title truncate-text">${currentTab.title}</span>`;
       const parser =  new DOMParser();
-      const parsed = parser.parseFromString(htmlText, `text/html`);
-      const tags = parsed.getElementsByTagName(`body`)
+      const parsed = parser.parseFromString("htmlText", "text/html");
+      const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
-      currentPage.appendChild(tag)
+        currentPage.appendChild(tag);
       }
       
       const favIconElement = Utils.createFavIconElement(currentTab.favIconUrl || "");
@@ -656,11 +656,11 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
           </div>
         </div>
         <div class="container-name truncate-text"></div>`;
-      const parser = new DOMParser()
-      const parsed = parser.parseFromString(htmlText, `text/html`)
-      const tags = parsed.getElementsByTagName(`body`)
+      const parser = new DOMParser();
+      const parsed = parser.parseFromString("htmlText", "text/html");
+      const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
-      currentPage.appendChild(tag)
+        context.appendChild(tag);
       }      
       
       context.querySelector(".container-name").textContent = identity.name;
@@ -821,11 +821,11 @@ Logic.registerPanel(P_CONTAINER_INFO, {
       const htmlText= escaped`
         <td></td>
         <td class="container-info-tab-title truncate-text" title="${tab.url}" ><div class="container-tab-title">${tab.title}</div></td>`;
-      const parser = new DOMParser()
-      const parsed = parser.parseFromString(htmlText, `text/html`)
-      const tags = parsed.getElementsByTagName(`body`)
+      const parser = new DOMParser();
+      const parsed = parser.parseFromString("htmlText", "text/html");
+      const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
-      tr.appendChild(tag)
+        tr.appendChild(tag);
       }
       
       tr.querySelector("td").appendChild(Utils.createFavIconElement(tab.favIconUrl));
@@ -909,11 +909,11 @@ Logic.registerPanel(P_CONTAINERS_EDIT, {
             src="/img/container-delete.svg"
           />
         </td>`;
-      const parser = new DOMParser()
-      const parsed = parser.parseFromString(htmlText, `text/html`)
-      const tags = parsed.getElementsByTagName(`body`)
+      const parser = new DOMParser();
+      const parsed = parser.parseFromString("htmlText", "text/html");
+      const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
-      tr.appendChild(tag)
+        tr.appendChild(tag);
       }
       
       tr.querySelector(".container-name").textContent = identity.name;
@@ -1024,11 +1024,11 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
           class="pop-button-image delete-assignment"
           src="/img/container-delete.svg"
         />`;
-        const parser = new DOMParser()
-        const parsed = parser.parseFromString(htmlText, `text/html`)
-        const tags = parsed.getElementsByTagName(`body`)
+        const parser = new DOMParser();
+        const parsed = parser.parseFromString("htmlText", "text/html");
+        const tags = parsed.getElementsByTagName("body");
         for (const tag of tags) {
-        trElement.appendChild(tag)
+          trElement.appendChild(tag);
         }       
         
         trElement.getElementsByClassName("favicon")[0].appendChild(Utils.createFavIconElement(assumedUrl));
@@ -1061,11 +1061,11 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       templateInstance.classList.add("radio-container");
       // eslint-disable-next-line no-unsanitized/property     
       const htmlText = colorRadioTemplate(containerColor);
-      const parser = new DOMParser()
-      const parsed = parser.parseFromString(htmlText, `text/html`)
-      const tags = parsed.getElementsByTagName(`body`)
+      const parser = new DOMParser();
+      const parsed = parser.parseFromString("htmlText", "text/html");
+      const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
-      templateInstance.appendChild(tag)
+        templateInstance.appendChild(tag);
       }
       
       colorRadioFieldset.appendChild(templateInstance);
@@ -1082,11 +1082,11 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       templateInstance.classList.add("radio-container");
       // eslint-disable-next-line no-unsanitized/property
       const htmlText= iconRadioTemplate(containerIcon);
-      const parser = new DOMParser()
-      const parsed = parser.parseFromString(htmlText, `text/html`)
-      const tags = parsed.getElementsByTagName(`body`)
+      const parser = new DOMParser();
+      const parsed = parser.parseFromString("htmlText", "text/html");
+      const tags = parsed.getElementsByTagName("body");
       for (const tag of tags) {
-      templateInstance.appendChild(tag)
+        templateInstance.appendChild(tag);
       }
       
       iconRadioFieldset.appendChild(templateInstance);


### PR DESCRIPTION
### #outreachy applicant fixes #973  and #1513 
I **refactored badge.displayBrowserActionBadge to be used in messageHandler**. However my various **attempts to reuse it in pop.js resulted in  error**, as the 'browser Action Badge' when clicked did not display anything. 

**Test**
I set the number of container tabs that's required to show 'achievement' to 5 (I have changed this back to hundred after testing). The tests were successful.

**Problem reusing in pop.js**
The picture below is how I attempted to make badge.displayBrowserActionBadge to be used in pop.js that resulted in unexpected behaviour, kindly review and advise me on what the bugs could be, thank you. I have removed this code below from the pull request 

![image](https://user-images.githubusercontent.com/52966744/66584533-3be7d800-eb7d-11e9-9b43-e9167b1d61fe.png)