### PR TITLE
Explicitly set foreground color of #redirect-url in dark mode

### DIFF
--- a/src/css/confirm-page.css
+++ b/src/css/confirm-page.css
@@ -60,6 +60,7 @@ html {
 @media (prefers-color-scheme: dark) {
   #redirect-url {
     background: #38383d; /* Grey 70 */
+    color: #eee; /* White 20 */
   }
 }
 /* stylelint-enable */


### PR DESCRIPTION
When using Firefox Multi-Account Containers in KDE Plasma, with a dark theme applied, the `#redirect-url` element contrast is very poor (black-on-black basically):
![image](https://user-images.githubusercontent.com/262645/66708683-56a78180-ed22-11e9-8853-e93e4b7d6e9d.png)

This tiny PR sets the foreground color (via dark mode media query) to be `#eee`, or slightly-dimmed white:
![image](https://user-images.githubusercontent.com/262645/66708700-c87fcb00-ed22-11e9-8d37-50e0923ec101.png)

All tests passed via `npm test`.