### PR TITLE
Backup & Restore containers configuration

### DIFF
--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -72,6 +72,12 @@ const messageHandler = {
           windowId: m.windowId
         });
         break;
+      case "backupIdentitiesState":
+        response = backgroundLogic.backupIdentitiesState();
+        break;
+      case "restoreIdentitiesState":
+        response = backgroundLogic.restoreIdentitiesState(m.identities);
+        break;
       case "queryIdentitiesState":
         response = backgroundLogic.queryIdentitiesState(m.message.windowId);
         break;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -53,6 +53,56 @@ async function enableDisableReplaceTab() {
   await browser.storage.local.set({replaceTabEnabled: !!checkbox.checked});
 }
 
+async function backupContainers() {
+  const backupLink = document.getElementById("containers-save-link");
+  const backupResult = document.getElementById("containers-save-result");
+  try {
+    const content = JSON.stringify(
+      await browser.runtime.sendMessage({
+        method: "backupIdentitiesState"
+      })
+    );
+    backupLink.href = `data:application/json;base64,${btoa(content)}`;
+    backupLink.download = `containers-backup-${(new Date()).toISOString()}.json`;
+    backupLink.click();
+    backupResult.textContent = "";
+  } catch (err) {
+    backupResult.textContent = browser.i18n.getMessage("backupFailure", [String(err.message || err)]);
+    backupResult.style.color = "red";
+  }
+}
+
+async function restoreContainers(event) {
+  const restoreInput = event.currentTarget;
+  const restoreResult = document.getElementById("containers-restore-result");
+  event.preventDefault();
+  if (restoreInput.files.length) {
+    const reader = new FileReader();
+    reader.onloadend = async () => {
+      try {
+        const identitiesState = JSON.parse(reader.result);
+        const { created: restoredCount, incomplete } = await browser.runtime.sendMessage({
+          method: "restoreIdentitiesState",
+          identities: identitiesState
+        });
+        if (incomplete.length === 0) {
+          restoreResult.textContent = browser.i18n.getMessage("containersRestored", [String(restoredCount)]);
+          restoreResult.style.color = "green";
+        } else {
+          restoreResult.textContent = browser.i18n.getMessage("containersPartiallyRestored", [String(restoredCount), String(incomplete.join(", "))]);
+          restoreResult.style.color = "orange";
+        }
+      } catch (err) {
+        console.error("Cannot restore containers list: %s", err.message || err);
+        restoreResult.textContent = browser.i18n.getMessage("containersRestorationFailed");
+        restoreResult.style.color = "red";
+      }
+    };
+    reader.readAsText(restoreInput.files.item(0));
+  }
+  restoreInput.value = "";
+}
+
 async function setupOptions() {
   const { syncEnabled } = await browser.storage.local.get("syncEnabled");
   const { replaceTabEnabled } = await browser.storage.local.get("replaceTabEnabled");
@@ -114,6 +164,7 @@ browser.permissions.onRemoved.addListener(resetPermissionsUi);
 document.addEventListener("DOMContentLoaded", setupOptions);
 document.querySelector("#syncCheck").addEventListener( "change", enableDisableSync);
 document.querySelector("#replaceTabCheck").addEventListener( "change", enableDisableReplaceTab);
+document.querySelector("#containersRestoreInput").addEventListener( "change", restoreContainers);
 maybeShowPermissionsWarningIcon();
 for (let i=0; i < NUMBER_OF_KEYBOARD_SHORTCUTS; i++) {
   document.querySelector("#open_container_"+i)
@@ -121,8 +172,12 @@ for (let i=0; i < NUMBER_OF_KEYBOARD_SHORTCUTS; i++) {
 }
 
 document.querySelectorAll("[data-btn-id]").forEach(btn => {
-  btn.addEventListener("click", () => {
+  btn.addEventListener("click", e => {
     switch (btn.dataset.btnId) {
+    case "containers-save-button":
+      e.preventDefault();
+      backupContainers();
+      break;
     case "reset-onboarding":
       resetOnboarding();
       break;

--- a/src/options.html
+++ b/src/options.html
@@ -59,6 +59,24 @@
         <p><em data-i18n-message-id="replaceTabDescription"></em></p>
       </div>
 
+      <h3 data-i18n-message-id="backup"></h3>
+
+      <div class="settings-group">
+        <fieldset>
+          <legend data-i18n-message-id="restoreLegend"></legend>
+          <input id="containersRestoreInput" type="file">
+          <p><em id="containers-restore-result"></em></p>
+          <p data-i18n-message-id="warningConfigOverride"></p>
+        </fieldset>
+        <fieldset>
+          <legend data-i18n-message-id="saveLegend"></legend>
+          <a id="containers-save-link" href="#" style="display: none;"></a>
+          <button data-i18n-message-id="saveButton" data-btn-id="containers-save-button"></button>
+          <p><em id="containers-save-result"></em></p>
+          <p data-i18n-message-id="noteWontBackupCookies"></p>
+        </fieldset>
+      </div>
+
       <h3 data-i18n-message-id="keyboardShortCuts"></h3>
       <p><em data-i18n-message-id="editWhichContainer"></em></p>
 


### PR DESCRIPTION
Fix #1282
Fix #1409
Fix #1427
Fix #1455

This PR is not a fix for the bug that reset containers list, it just add buttons in the Options UI of the extension in `about:addons` to backup and restore the containers list.

Please note that currently, only containers' colors, icons, names and site associations are saved, *not cookies*, which means **containers' sessions are erased when importing a backup**.

Moreover, this PR allows to configure containers list with JSON directly, and to share configurations across browsers easily.

All tests passed via `npm run test`.

EDIT : Now, backup and restore site associations :wink: 
EDIT 2 : Localization messages available here: mozilla-l10n/multi-account-containers-l10n#11