### PR TITLE
Fix for double decoding on confirm page issue #1361

### DIFF
--- a/src/js/confirm-page.js
+++ b/src/js/confirm-page.js
@@ -1,6 +1,6 @@
 async function load() {
   const searchParams = new URL(window.location).searchParams;
-  const redirectUrl = decodeURIComponent(searchParams.get("url"));
+  const redirectUrl = searchParams.get("url");
   const cookieStoreId = searchParams.get("cookieStoreId");
   const currentCookieStoreId = searchParams.get("currentCookieStoreId");
   const redirectUrlElement = document.getElementById("redirect-url");


### PR DESCRIPTION
Fix for #1361 

# Steps to reproduce bug:
from: https://bugzilla.mozilla.org/show_bug.cgi?id=1535643
1. Go to https://www.example.com/path?param=some%2Bvalue in a container
2. Mark it to "Always open in <container>"
3. Open a new tab outside of the container
4. Go to https://www.example.com/path?param=some%2Bvalue
5. Look at the "Open this site in your assigned container?" page

Actual results:
Redirect url is show as "https://www.example.com/path?param=some+value" - notice that "some%2Bvalue" is now "some+value".  Open in <container> button will also open that url and not the original.

Expected results:
Redirect url should show as "https://www.example.com/path?param=some%2Bvalue". Open in <container> button should also open that url.

# Test fix
Repeat above steps. Other urls with special characters still work.

Some other urls to test:
https://www.target.com/s?searchTerm=spiderman+costume
https://github.com/search?q=unicorn+horns
kendallcorner.com/test%25file.html (not a valid url, but it will show a change on the "Open this site in your assigned container?" page in the unfixed version.)

