### PR TITLE
added keyboard nav to onboarding popups

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -382,6 +382,11 @@ const Logic = {
       }
     }
   },
+
+  getCurrentPanel() {
+    const panelItem = this._panels[this._currentPanel];
+    return document.querySelector(this.getPanelSelector(panelItem));
+  },
 };
 
 // P_ONBOARDING_1: First page for Onboarding.
@@ -550,6 +555,14 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       case 38:
         previous();
         break;
+      case 13: {
+        const panel = Logic.getCurrentPanel();
+        const button = panel.getElementsByTagName("A")[0];
+        if(button) {
+          button.click();
+        }
+        break;
+      }
       default:
         if ((e.keyCode >= 49 && e.keyCode <= 57) &&
             Logic._currentPanel === "containersList") {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -383,7 +383,7 @@ const Logic = {
     }
   },
 
-  getCurrentPanel() {
+  getCurrentPanelElement() {
     const panelItem = this._panels[this._currentPanel];
     return document.querySelector(this.getPanelSelector(panelItem));
   },
@@ -556,7 +556,7 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
         previous();
         break;
       case 13: {
-        const panel = Logic.getCurrentPanel();
+        const panel = Logic.getCurrentPanelElement();
         const button = panel.getElementsByTagName("A")[0];
         if(button) {
           button.click();


### PR DESCRIPTION
Addresses Issue #1538 

This patch allows user to navigate through onboarding panels (e.g. Get Started) via pressing "return" on the keyboard.

#OutreachyApplicant