### PR TITLE
#950: don't unhide duplicates of already opened tab

### DIFF
--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -113,12 +113,12 @@ const backgroundLogic = {
     return list.concat(containerState.hiddenTabs);
   },
 
-  async unhideContainer(cookieStoreId, toHide) {
+  async unhideContainer(cookieStoreId, alreadyShowingUrl) {
     if (!this.unhideQueue.includes(cookieStoreId)) {
       this.unhideQueue.push(cookieStoreId);
       await this.showTabs({
         cookieStoreId,
-        toHide
+        alreadyShowingUrl
       });
       this.unhideQueue.splice(this.unhideQueue.indexOf(cookieStoreId), 1);
     }
@@ -311,7 +311,7 @@ const backgroundLogic = {
 
     for (let object of containerState.hiddenTabs) { // eslint-disable-line prefer-const
       // do not show already opened url
-      if (object.url !== options.toHide) {
+      if (object.url !== options.alreadyShowingUrl) {
         promises.push(this.openNewTab({
           userContextId: userContextId,
           url: object.url,

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -113,11 +113,12 @@ const backgroundLogic = {
     return list.concat(containerState.hiddenTabs);
   },
 
-  async unhideContainer(cookieStoreId) {
+  async unhideContainer(cookieStoreId, toHide) {
     if (!this.unhideQueue.includes(cookieStoreId)) {
       this.unhideQueue.push(cookieStoreId);
       await this.showTabs({
-        cookieStoreId
+        cookieStoreId,
+        toHide
       });
       this.unhideQueue.splice(this.unhideQueue.indexOf(cookieStoreId), 1);
     }
@@ -309,12 +310,16 @@ const backgroundLogic = {
     const containerState = await identityState.storageArea.get(options.cookieStoreId);
 
     for (let object of containerState.hiddenTabs) { // eslint-disable-line prefer-const
-      promises.push(this.openNewTab({
-        userContextId: userContextId,
-        url: object.url,
-        nofocus: options.nofocus || false,
-        pinned: object.pinned,
-      }));
+      // do not show already opened url
+      if (object.url !== options.toHide) {
+        promises.push(this.openNewTab({
+          userContextId: userContextId,
+          url: object.url,
+          nofocus: options.nofocus || false,
+          pinned: object.pinned,
+        }));
+      }
+
     }
 
     containerState.hiddenTabs = [];

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -153,25 +153,25 @@ const messageHandler = {
             !tab.url.startsWith("moz-extension")) {
           // increment the counter of container tabs opened
           this.incrementCountOfContainerTabsOpened();
-        }
 
-        this.tabUpdateHandler = (tabId, changeInfo) => {
-          if (tabId === tab.id && changeInfo.status === "complete") {
-            // get current tab's url to not open the same one from hidden tabs
-            browser.tabs.get(tabId).then(loadedTab => {
-              backgroundLogic.unhideContainer(tab.cookieStoreId, loadedTab.url);
-            }).catch((e) => {
-              throw e;
-            });
+          this.tabUpdateHandler = (tabId, changeInfo) => {
+            if (tabId === tab.id && changeInfo.status === "complete") {
+              // get current tab's url to not open the same one from hidden tabs
+              browser.tabs.get(tabId).then(loadedTab => {
+                backgroundLogic.unhideContainer(tab.cookieStoreId, loadedTab.url);
+              }).catch((e) => {
+                throw e;
+              });
 
-            browser.tabs.onUpdated.removeListener(this.tabUpdateHandler);
+              browser.tabs.onUpdated.removeListener(this.tabUpdateHandler);
+            }
+          };
+
+          // if it's a container tab wait for it to complete and
+          // unhide other tabs from this container
+          if (tab.cookieStoreId.startsWith("firefox-container")) {
+            browser.tabs.onUpdated.addListener(this.tabUpdateHandler);
           }
-        };
-
-        // if it's a container tab wait for it to complete and
-        // unhide other tabs from this container
-        if (tab.cookieStoreId.startsWith("firefox-container")) {
-          browser.tabs.onUpdated.addListener(this.tabUpdateHandler);
         }
       }
       setTimeout(() => {


### PR DESCRIPTION
fix for https://github.com/mozilla/multi-account-containers/issues/950
Issue: If you open a tab, which was assigned to some containers and you have some hidden tabs from this container at the moment, all the hidden tabs will be opened again. 

Solution: check if the url of the hidden tab was already opened and if so skip it from re-opening to prevent duplicates. 