### PR TITLE
identities list in container panel is now tabbable and buttons are ac…

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -639,6 +639,7 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       manage.classList.add("show-tabs", "pop-button");
       manage.setAttribute("title", `View ${identity.name} container`);
       context.setAttribute("tabindex", "0");
+      manage.setAttribute("tabindex", "0");
       context.setAttribute("title", `Create ${identity.name} tab`);
       context.innerHTML = escaped`
         <div class="userContext-icon-wrapper open-newtab">
@@ -660,7 +661,10 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       }
 
       Logic.addEnterHandler(tr, async (e) => {
-        if (e.target.matches(".open-newtab")
+        if (e.target.matches(".show-tabs") && hasTabs) {
+          Logic.showPanel(P_CONTAINER_INFO, identity);
+        }
+        else if (e.target.matches(".open-newtab")
           || e.target.parentNode.matches(".open-newtab")
           || e.type === "keydown") {
           try {
@@ -671,8 +675,6 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
           } catch (e) {
             window.close();
           }
-        } else if (hasTabs) {
-          Logic.showPanel(P_CONTAINER_INFO, identity);
         }
       });
     });

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -588,7 +588,8 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       default:
         if ((e.keyCode >= 49 && e.keyCode <= 57) &&
             Logic._currentPanel === "containersList") {
-          const element = selectables[e.keyCode - 48];
+          const containers = document.querySelectorAll(".open-newtab");
+          const element = containers[e.keyCode - 48];
           if (element) {
             element.click();
           }


### PR DESCRIPTION
…cessible via enter key

#1547 
Before Fix: 
Here is a GIF screen recording before the added functionality. 
Notice we cannot tab through to the right Show Tabs arrows or press enter to show the corresponding Container Info panel.
![PanelTabbable](https://user-images.githubusercontent.com/2976514/67340554-915ba780-f4e2-11e9-967f-3e75a13562e1.gif)

After Fix:
Here is a GIF screen recording showing the added functionality. 
Notice we can now tab through to right Show Tabs arrows and press enter to show the corresponding Container Info panel.
![PanelTabbableFixed](https://user-images.githubusercontent.com/2976514/67340537-8a349980-f4e2-11e9-9457-19b033120304.gif)

