### PR TITLE
Fixes Issue #1553 Web-Ext needs update to version 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "ajv": "^6.6.2",
     "addons-linter": "^1.3.2",
+    "ajv": "^6.6.2",
     "chai": "^4.1.2",
     "eslint": "^3.17.1",
     "eslint-plugin-no-unsanitized": "^2.0.0",
@@ -25,7 +25,7 @@
     "stylelint": "^7.9.0",
     "stylelint-config-standard": "^16.0.0",
     "stylelint-order": "^0.3.0",
-    "web-ext": "^2.2.2"
+    "web-ext": "^3.2.0"
   },
   "homepage": "https://github.com/mozilla/multi-account-containers#readme",
   "license": "MPL-2.0",


### PR DESCRIPTION
Issue #1553 Web-Ext needs update to version 3.2.0

Updates Web-Ext to Version 3.2.0 in json package

### Before:
<img width="676" alt="Screen Shot 2019-10-23 at 5 14 54 PM" src="https://user-images.githubusercontent.com/2976514/67445117-8414ea80-f5c0-11e9-9b06-791f6555472d.png">

### After:
<img width="734" alt="Screen Shot 2019-10-23 at 5 30 40 PM" src="https://user-images.githubusercontent.com/2976514/67445121-870fdb00-f5c0-11e9-9715-9e50772a96e2.png">

