### PR TITLE
Fixes Issue #1555 Make edit containers panel tabbable

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -888,9 +888,12 @@ Logic.registerPanel(P_CONTAINERS_EDIT, {
           />
         </td>`;
       tr.querySelector(".container-name").textContent = identity.name;
-      tr.querySelector(".edit-container").setAttribute("title", `Edit ${identity.name} container`);
-      tr.querySelector(".remove-container").setAttribute("title", `Remove ${identity.name} container`);
-
+      const edit = tr.querySelector(".edit-container");
+      edit.setAttribute("title", `Edit ${identity.name} container`);
+      edit.setAttribute("tabindex", "0");
+      const remove = tr.querySelector(".remove-container");
+      remove.setAttribute("title", `Remove ${identity.name} container`);
+      remove.setAttribute("tabindex", "0");
 
       Logic.addEnterHandler(tr, e => {
         if (e.target.matches(".edit-container-icon") || e.target.parentNode.matches(".edit-container-icon")) {


### PR DESCRIPTION
Fixes Issue #1555 Make edit containers panel tabbable

## Before:
Screen recording of issue. Buttons not accessible via tabbing.
![EditContainersTabbing Issue](https://user-images.githubusercontent.com/2976514/67447470-d1955580-f5c8-11e9-8fa0-1badf6f8af56.gif)

## After:
Screen recording of fixed issue. Buttons now accessible via tabbing.
![EditContainersTabbing PR](https://user-images.githubusercontent.com/2976514/67448346-8c265780-f5cb-11e9-8367-05d6323232bc.gif)
