### PR TITLE
Added keyboard shortcuts to Edit Containers panel

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -890,6 +890,8 @@ Logic.registerPanel(P_CONTAINERS_EDIT, {
       tr.querySelector(".container-name").textContent = identity.name;
       tr.querySelector(".edit-container").setAttribute("title", `Edit ${identity.name} container`);
       tr.querySelector(".remove-container").setAttribute("title", `Remove ${identity.name} container`);
+      tr.querySelector(".edit-container").setAttribute("tabindex","0");
+      tr.querySelector(".remove-container").setAttribute("tabindex","0");
 
 
       Logic.addEnterHandler(tr, e => {


### PR DESCRIPTION
Tab, arrow-up and arrow-down keys can be used to navigate through the list of Edit Containers panel.
In reference to issue: #512