### PR TITLE
save confirm page url to the local storage as a backup #1027

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -490,6 +490,8 @@ const assignManager = {
         currentCookieStoreId = backgroundLogic.cookieStoreId(currentUserContextId);
         confirmUrl += `&currentCookieStoreId=${currentCookieStoreId}`;
       }
+
+      browser.storage.local.set({ "confirmUrl": confirmUrl});
       browser.tabs.create({
         url: confirmUrl,
         cookieStoreId: currentCookieStoreId,

--- a/src/js/confirm-page.js
+++ b/src/js/confirm-page.js
@@ -1,5 +1,12 @@
 async function load() {
-  const searchParams = new URL(window.location).searchParams;
+
+  let searchParams = new URL(window.location).searchParams;
+
+  if (!searchParams.get("url")) {
+    const savedUrl = await browser.storage.local.get("confirmUrl");
+    searchParams = new URL(savedUrl.confirmUrl).searchParams;
+  }
+
   const redirectUrl = searchParams.get("url");
   const cookieStoreId = searchParams.get("cookieStoreId");
   const currentCookieStoreId = searchParams.get("currentCookieStoreId");


### PR DESCRIPTION
fix for #1027 

for the cases when confirm page loads without search parameters and redirect url and container Id are lost, save confirmUrl to the local storage as a backup source of data. 