### PR TITLE
Container sync

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -712,8 +712,7 @@ async function reconcileIdentitiesByName(inSync){
   const cookieStoreIDmap = inSync.cookieStoreIDmap;
   for (const syncIdentity of inSync.identities) {
     syncIdentity.macAddonUUID = cookieStoreIDmap[syncIdentity.cookieStoreId];
-    const compareNames = function (localIdentity) { return (localIdentity.name === syncIdentity.name); };
-    const match = localIdentities.find(compareNames);
+    const match = localIdentities.find(localIdentity => localIdentity.name === syncIdentity.name);
     if (!match) {
       console.log("create new ident: ", syncIdentity.name)
       newIdentity = await browser.contextualIdentities.create({name: syncIdentity.name, color: syncIdentity.color, icon: syncIdentity.icon});

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -632,13 +632,13 @@ async function restore(inSync) {
   const browserIdentities = await browser.contextualIdentities.query({});
 
   for (const syncIdentity of syncIdentities) {
-    const compareNames = function (browserIdentity) { return (browserIdentity.name == syncIdentity.name); };
+    const compareNames = function (browserIdentity) { return (browserIdentity.name === syncIdentity.name); };
     const match = browserIdentities.find(compareNames);
     if (!match) {
       browser.contextualIdentities.create({name: syncIdentity.name, color: syncIdentity.color, icon: syncIdentity.icon});
       continue;
     } else {
-      if (syncIdentity.color == match.color && syncIdentity.icon == match.icon) {
+      if (syncIdentity.color === match.color && syncIdentity.icon === match.icon) {
         console.log("everything is the same:", syncIdentity, match);
         continue;
       }
@@ -655,14 +655,14 @@ async function restoreFirstRun(inSync) {
   const browserIdentities = await browser.contextualIdentities.query({});
   const syncIdentities = inSync.identities;
   for (const syncIdentity of inSync.identities) {
-    const compareNames = function (browserIdentity) { return (browserIdentity.name == syncIdentity.name); };
+    const compareNames = function (browserIdentity) { return (browserIdentity.name === syncIdentity.name); };
     const match = browserIdentities.find(compareNames);
     if (!match) {
       newIdentity = await browser.contextualIdentities.create({name: syncIdentity.name, color: syncIdentity.color, icon: syncIdentity.icon});
       identityState.updateUUID(newIdentity.cookieStoreId, syncIdentity.macUUID);
       continue;
     } else {
-      if (syncIdentity.color == match.color && syncIdentity.icon == match.icon) {
+      if (syncIdentity.color === match.color && syncIdentity.icon === match.icon) {
         console.log("everything is the same:", syncIdentity, match);
         continue;
       }
@@ -678,7 +678,7 @@ async function restoreFirstRun(inSync) {
     if (assignedSitesBrowser.hasOwnProperty(key)) {
       const syncCookieStoreId = "firefox-container-" + syncAssignedSites[key].userContextId;
       const browserCookieStoreId = "firefox-container-" + assignedSitesBrowser[key].userContextId;
-      if (inSync.cookieStoreIDmap[syncCookieStoreId] == identityState.storageArea.get(browserCookieStoreId).macUUID) {
+      if (inSync.cookieStoreIDmap[syncCookieStoreId] === identityState.storageArea.get(browserCookieStoreId).macUUID) {
         continue;
       } else {
         // ask user

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -564,10 +564,10 @@ const assignManager = {
     console.log("inLocal: ", localInfo);
     const beenSynced = await assignManager.storageArea.getSynced();
     if (beenSynced){
-      await runSync();
+      runSync();
       return;
     }
-    await runFirstSync();
+    runFirstSync();
   },
 };
 

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -569,8 +569,6 @@ const assignManager = {
 
   async initSync() {
     console.log("initSync");
-    // browser.storage.onChanged.addListener(runSync);
-    // addContextualIdentityListeners();
     const beenSynced = await assignManager.storageArea.getSynced();
     if (beenSynced){
       runSync();
@@ -596,21 +594,26 @@ async function backup() {
   browser.storage.onChanged.addListener(runSync);
 }
 
-browser.resetMAC = async function () {
+browser.resetMAC1 = async function () {
   // for debugging and testing: remove all containers except the default 4 and the first one created
   browser.storage.onChanged.removeListener(runSync);
 
   // sync state on install: no sync data
-  // await browser.storage.sync.clear();
+  await browser.storage.sync.clear();
 
   // FF1: no sync, Only default containers and 1 extra
-  // browser.storage.local.clear();
-  // const localData = {"browserActionBadgesClicked":["6.1.1"],"containerTabsOpened":6,"identitiesState@@_firefox-container-1":{"hiddenTabs":[]},"identitiesState@@_firefox-container-2":{"hiddenTabs":[]},"identitiesState@@_firefox-container-3":{"hiddenTabs":[]},"identitiesState@@_firefox-container-4":{"hiddenTabs":[]},"identitiesState@@_firefox-container-6":{"hiddenTabs":[]},"identitiesState@@_firefox-default":{"hiddenTabs":[]},"onboarding-stage":5,"siteContainerMap@@_twitter.com":{"userContextId":"1","neverAsk":true},"siteContainerMap@@_www.facebook.com":{"userContextId":"2","neverAsk":true},"siteContainerMap@@_www.linkedin.com":{"userContextId":"4","neverAsk":false}};
-  // browser.storage.local.set(localData);
+  browser.storage.local.clear();
+  const localData = {"browserActionBadgesClicked":["6.1.1"],"containerTabsOpened":6,"identitiesState@@_firefox-container-1":{"hiddenTabs":[]},"identitiesState@@_firefox-container-2":{"hiddenTabs":[]},"identitiesState@@_firefox-container-3":{"hiddenTabs":[]},"identitiesState@@_firefox-container-4":{"hiddenTabs":[]},"identitiesState@@_firefox-container-6":{"hiddenTabs":[]},"identitiesState@@_firefox-default":{"hiddenTabs":[]},"onboarding-stage":5,"siteContainerMap@@_twitter.com":{"userContextId":"1","neverAsk":true},"siteContainerMap@@_www.facebook.com":{"userContextId":"2","neverAsk":true},"siteContainerMap@@_www.linkedin.com":{"userContextId":"4","neverAsk":false}};
+  browser.storage.local.set(localData);
+};
+
+browser.resetMAC2 = async function () {
+  // for debugging and testing: remove all containers except the default 4 and the first one created
+  browser.storage.onChanged.removeListener(runSync);
 
   // sync state after FF1 (default + 1)
   await browser.storage.sync.clear();
-  const syncData = {"cookieStoreIDmap":{"firefox-container-1":"38eb85cc-0793-47c3-b51f-a4f1edf8908c","firefox-container-2":"19fcfbe5-c9ae-4445-8c8b-a7853e3d4462","firefox-container-3":"ac97270e-ccf6-4121-8d7f-74b764c5c78f","firefox-container-4":"595ae5cf-669c-4461-a738-05d3321d923e","firefox-container-6":"b39de7b4-b169-4128-bca3-e73f0376d9ed"},"assignedSites":{"siteContainerMap@@_twitter.com":{"userContextId":"1","neverAsk":!0,"userContextUUID":"38eb85cc-0793-47c3-b51f-a4f1edf8908c"},"siteContainerMap@@_www.facebook.com":{"userContextId":"2","neverAsk":!0,"userContextUUID":"19fcfbe5-c9ae-4445-8c8b-a7853e3d4462"},"siteContainerMap@@_www.linkedin.com":{"userContextId":"4","neverAsk":!1,"userContextUUID":"595ae5cf-669c-4461-a738-05d3321d923e"}},"identities":[{"name":"Personal","icon":"fingerprint","iconUrl":"resource://usercontext-content/fingerprint.svg","color":"blue","colorCode":"#37adff","cookieStoreId":"firefox-container-1"},{"name":"Work","icon":"briefcase","iconUrl":"resource://usercontext-content/briefcase.svg","color":"orange","colorCode":"#ff9f00","cookieStoreId":"firefox-container-2"},{"name":"Banking","icon":"dollar","iconUrl":"resource://usercontext-content/dollar.svg","color":"green","colorCode":"#51cd00","cookieStoreId":"firefox-container-3"},{"name":"Shopping","icon":"cart","iconUrl":"resource://usercontext-content/cart.svg","color":"pink","colorCode":"#ff4bda","cookieStoreId":"firefox-container-4"},{"name":"Container #01","icon":"chill","iconUrl":"resource://usercontext-content/chill.svg","color":"green","colorCode":"#51cd00","cookieStoreId":"firefox-container-6"}]};
+  const syncData = {"cookieStoreIDmap":{"firefox-container-1":"4dc76734-5b71-4f2e-85d0-1cb199ae3821","firefox-container-2":"30308b8d-393c-4375-b9a1-afc59f0dea79","firefox-container-3":"7419c94d-85d7-4d76-94c0-bacef1de722f","firefox-container-4":"2b9fe881-e552-4df9-8cab-922f4688bb68","firefox-container-6":"db7f622e-682b-4556-968a-6e2542ff3b26"},"assignedSites":{"siteContainerMap@@_twitter.com":{"userContextId":"1","neverAsk":!0},"siteContainerMap@@_www.facebook.com":{"userContextId":"2","neverAsk":!0},"siteContainerMap@@_www.linkedin.com":{"userContextId":"4","neverAsk":!1}},"identities":[{"name":"Personal","icon":"fingerprint","iconUrl":"resource://usercontext-content/fingerprint.svg","color":"blue","colorCode":"#37adff","cookieStoreId":"firefox-container-1"},{"name":"Work","icon":"briefcase","iconUrl":"resource://usercontext-content/briefcase.svg","color":"orange","colorCode":"#ff9f00","cookieStoreId":"firefox-container-2"},{"name":"Banking","icon":"dollar","iconUrl":"resource://usercontext-content/dollar.svg","color":"green","colorCode":"#51cd00","cookieStoreId":"firefox-container-3"},{"name":"Shopping","icon":"cart","iconUrl":"resource://usercontext-content/cart.svg","color":"pink","colorCode":"#ff4bda","cookieStoreId":"firefox-container-4"},{"name":"Container #01","icon":"chill","iconUrl":"resource://usercontext-content/chill.svg","color":"green","colorCode":"#51cd00","cookieStoreId":"firefox-container-6"}]};
   browser.storage.sync.set(syncData);
 
   // FF2 (intial sync w/ default 4 + 1 with some changes)
@@ -618,7 +621,7 @@ browser.resetMAC = async function () {
   browser.contextualIdentities.update("firefox-container-2", {color:"purple"});
   browser.contextualIdentities.update("firefox-container-4", {icon:"pet"});
   browser.storage.local.clear();
-  const localData = {"browserActionBadgesClicked":["6.1.1"],"containerTabsOpened":6,"identitiesState@@_firefox-container-1":{"hiddenTabs":[]},"identitiesState@@_firefox-container-2":{"hiddenTabs":[]},"identitiesState@@_firefox-container-3":{"hiddenTabs":[]},"identitiesState@@_firefox-container-4":{"hiddenTabs":[]},"identitiesState@@_firefox-container-6":{"hiddenTabs":[]},"identitiesState@@_firefox-default":{"hiddenTabs":[]},"onboarding-stage":5,"siteContainerMap@@_twitter.com":{"userContextId":"1","neverAsk":!0},"siteContainerMap@@_www.facebook.com":{"userContextId":"2","neverAsk":!0},"siteContainerMap@@_www.linkedin.com":{"userContextId":"4","neverAsk":!1}};
+  const localData = {"browserActionBadgesClicked":["6.1.1"],"containerTabsOpened":7,"identitiesState@@_firefox-container-1":{"hiddenTabs":[]},"identitiesState@@_firefox-container-2":{"hiddenTabs":[]},"identitiesState@@_firefox-container-3":{"hiddenTabs":[]},"identitiesState@@_firefox-container-4":{"hiddenTabs":[]},"identitiesState@@_firefox-container-6":{"hiddenTabs":[]},"identitiesState@@_firefox-default":{"hiddenTabs":[]},"onboarding-stage":5,"siteContainerMap@@_developer.mozilla.org":{"userContextId":"6","neverAsk":!1},"siteContainerMap@@_twitter.com":{"userContextId":"1","neverAsk":!0},"siteContainerMap@@_www.linkedin.com":{"userContextId":"4","neverAsk":!1}};
   browser.storage.local.set(localData);
 
 };
@@ -642,6 +645,62 @@ async function restore(inSync) {
       console.log("somethings are different:", syncIdentity, match);
       browser.contextualIdentities.update(match.cookieStoreId, {name: syncIdentity.name, color: syncIdentity.color, icon: syncIdentity.icon});
     }
+  }
+  backup();
+  addContextualIdentityListeners();
+}
+
+async function restoreFirstRun(inSync) {
+  removeContextualIdentityListeners();
+  const browserIdentities = await browser.contextualIdentities.query({});
+  const syncIdentities = inSync.identities;
+  for (const syncIdentity of inSync.identities) {
+    const compareNames = function (browserIdentity) { return (browserIdentity.name == syncIdentity.name); };
+    const match = browserIdentities.find(compareNames);
+    if (!match) {
+      newIdentity = await browser.contextualIdentities.create({name: syncIdentity.name, color: syncIdentity.color, icon: syncIdentity.icon});
+      identityState.updateUUID(newIdentity.cookieStoreId, syncIdentity.macUUID);
+      continue;
+    } else {
+      if (syncIdentity.color == match.color && syncIdentity.icon == match.icon) {
+        console.log("everything is the same:", syncIdentity, match);
+        continue;
+      }
+      console.log("somethings are different:", syncIdentity, match);
+      browser.contextualIdentities.update(match.cookieStoreId, {name: syncIdentity.name, color: syncIdentity.color, icon: syncIdentity.icon});
+    }
+  }
+  const assignedSitesBrowser = await assignManager.storageArea.getAllAssignedSites();
+  console.log(assignedSitesBrowser);
+  const syncAssignedSites = inSync.assignedSites;
+  console.log(syncAssignedSites);
+  for(const key of Object.keys(syncAssignedSites)) {
+    if (assignedSitesBrowser.hasOwnProperty(key)) {
+      const syncCookieStoreId = "firefox-container-" + syncAssignedSites[key].userContextId;
+      const browserCookieStoreId = "firefox-container-" + assignedSitesBrowser[key].userContextId;
+      if (inSync.cookieStoreIDmap[syncCookieStoreId] == identityState.storageArea.get(browserCookieStoreId).macUUID) {
+        continue;
+      } else {
+        // ask user
+      }
+    } else {
+      const data = syncAssignedSites[key];
+      console.log("data", data);
+      const newUUID = inSync.cookieStoreIDmap["firefox-container-" + data.userContextId];
+      console.log("newUUID", newUUID);
+      data.userContextId = identityState.lookupCookieStoreId(newUUID);
+      console.log(data.userContextId);
+      assignManager.storageArea.set(
+        key.replace(/^siteContainerMap@@_/, "https://"),
+        data
+      );
+    }
+
+
+    // if (String(syncAssignedSites[key].userContextId) === String(syncIdentity.userContextId)) {
+    //   // const site = siteConfigs[key];
+    //   // sites[key] = site;
+    // }
   }
   backup();
   addContextualIdentityListeners();
@@ -675,8 +734,15 @@ async function runFirstSync() {
   console.log("runFirstSync");
   const browserIdentities = await browser.contextualIdentities.query({});
   addUUIDsToContainers(browserIdentities);
-  connectUUIDsToAssignedSites(browserIdentities);
-  runSync();
+  // connectUUIDsToAssignedSites(browserIdentities);
+  const inSync = await browser.storage.sync.get();
+  if (Object.entries(inSync).length === 0){
+    console.log("no sync storage, backing up...");
+    backup();
+  } else {
+    console.log("storage found, attempting to restore ...");
+    restoreFirstRun(inSync);
+  }
   assignManager.storageArea.setSynced();
 }
 
@@ -686,11 +752,11 @@ async function addUUIDsToContainers(browserIdentities) {
   }
 }
 
-async function connectUUIDsToAssignedSites(browserIdentities) {
-  const assignedSites = await assignManager.storageArea.getAllAssignedSites();
-  for (const siteKey of Object.keys(assignedSites)) {
-    const identity = await identityState.storageArea.get("firefox-container-" + assignedSites[siteKey].userContextId);
-    assignedSites[siteKey].userContextUUID = identity.macUUID;
-    assignManager.storageArea.area.set({ [siteKey]: assignedSites[siteKey] });
-  }
-}
+// async function connectUUIDsToAssignedSites(browserIdentities) {
+//   const assignedSites = await assignManager.storageArea.getAllAssignedSites();
+//   for (const siteKey of Object.keys(assignedSites)) {
+//     const identity = await identityState.storageArea.get("firefox-container-" + assignedSites[siteKey].userContextId);
+//     assignedSites[siteKey].userContextUUID = identity.macUUID;
+//     assignManager.storageArea.area.set({ [siteKey]: assignedSites[siteKey] });
+//   }
+// }

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -695,12 +695,6 @@ async function restoreFirstRun(inSync) {
         data
       );
     }
-
-
-    // if (String(syncAssignedSites[key].userContextId) === String(syncIdentity.userContextId)) {
-    //   // const site = siteConfigs[key];
-    //   // sites[key] = site;
-    // }
   }
   backup();
   addContextualIdentityListeners();
@@ -734,7 +728,6 @@ async function runFirstSync() {
   console.log("runFirstSync");
   const browserIdentities = await browser.contextualIdentities.query({});
   addUUIDsToContainers(browserIdentities);
-  // connectUUIDsToAssignedSites(browserIdentities);
   const inSync = await browser.storage.sync.get();
   if (Object.entries(inSync).length === 0){
     console.log("no sync storage, backing up...");
@@ -751,12 +744,3 @@ async function addUUIDsToContainers(browserIdentities) {
     identityState.addUUID(identity.cookieStoreId);
   }
 }
-
-// async function connectUUIDsToAssignedSites(browserIdentities) {
-//   const assignedSites = await assignManager.storageArea.getAllAssignedSites();
-//   for (const siteKey of Object.keys(assignedSites)) {
-//     const identity = await identityState.storageArea.get("firefox-container-" + assignedSites[siteKey].userContextId);
-//     assignedSites[siteKey].userContextUUID = identity.macUUID;
-//     assignManager.storageArea.area.set({ [siteKey]: assignedSites[siteKey] });
-//   }
-// }

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -587,8 +587,8 @@ async function backup() {
   console.log("in sync: ", storage);
   const localStorage = await browser.storage.local.get();
   console.log("inLocal:", localStorage);
-  //browser.storage.onChanged.addListener(syncOnChangedListener);
-  //addContextualIdentityListeners(backup);
+  await browser.storage.onChanged.addListener(syncOnChangedListener);
+  await addContextualIdentityListeners(backup);
 }
 
 browser.resetMAC1 = async function () {

--- a/src/js/background/identityState.js
+++ b/src/js/background/identityState.js
@@ -70,10 +70,11 @@ const identityState = {
   async updateUUID(cookieStoreId, uuid) {
     const containerState = await this.storageArea.get(cookieStoreId);
     containerState.macAddonUUID = uuid;
-    return this.storageArea.set(cookieStoreId, containerState);
+    await this.storageArea.set(cookieStoreId, containerState);
+    return;
   },
   async addUUID(cookieStoreId) {
-    return this.updateUUID(cookieStoreId, uuidv4());
+    return await this.updateUUID(cookieStoreId, uuidv4());
   },
 
   async lookupMACaddonUUID(cookieStoreId) {

--- a/src/js/background/identityState.js
+++ b/src/js/background/identityState.js
@@ -77,12 +77,10 @@ const identityState = {
   },
 
   async lookupCookieStoreId(macUUID) {
-    console.log("luCSI");
     const macConfigs = await this.storageArea.area.get();
     for(const key of Object.keys(macConfigs)) {
       if (key.includes("identitiesState@@_")) {
         if(macConfigs[key].macUUID === macUUID) {
-          console.log(key);
           return key.replace(/^firefox-container-@@_/, "");
         }
       }

--- a/src/js/background/identityState.js
+++ b/src/js/background/identityState.js
@@ -76,12 +76,24 @@ const identityState = {
     return this.updateUUID(cookieStoreId, uuidv4());
   },
 
+  async lookupMACaddonUUID(cookieStoreId) {
+    const macConfigs = await this.storageArea.area.get();
+    for(const key of Object.keys(macConfigs)) {
+      if (key.includes("identitiesState@@_")) {
+        if(macConfigs[key] === cookieStoreId) {
+          return macConfigs[key].macAddonUUID;
+        }
+      }
+    }
+    return false;
+  },
+
   async lookupCookieStoreId(macAddonUUID) {
     const macConfigs = await this.storageArea.area.get();
     for(const key of Object.keys(macConfigs)) {
       if (key.includes("identitiesState@@_")) {
         if(macConfigs[key].macAddonUUID === macAddonUUID) {
-          return key.replace(/^firefox-container-@@_/, "");
+          return String(key).replace(/^identitiesState@@_/, "");
         }
       }
     }

--- a/src/js/background/identityState.js
+++ b/src/js/background/identityState.js
@@ -44,7 +44,7 @@ const identityState = {
       if (key.includes("identitiesState@@_")) {
         const container = containerInfo[key];
         const cookieStoreId = key.replace(/^identitiesState@@_/, "");
-        containers[cookieStoreId] = container.macUUID;
+        containers[cookieStoreId] = container.macAddonUUID;
       }
     }
     return containers;
@@ -69,18 +69,18 @@ const identityState = {
   },
   async updateUUID(cookieStoreId, uuid) {
     const containerState = await this.storageArea.get(cookieStoreId);
-    containerState.macUUID = uuid;
+    containerState.macAddonUUID = uuid;
     return this.storageArea.set(cookieStoreId, containerState);
   },
   async addUUID(cookieStoreId) {
     return this.updateUUID(cookieStoreId, uuidv4());
   },
 
-  async lookupCookieStoreId(macUUID) {
+  async lookupCookieStoreId(macAddonUUID) {
     const macConfigs = await this.storageArea.area.get();
     for(const key of Object.keys(macConfigs)) {
       if (key.includes("identitiesState@@_")) {
-        if(macConfigs[key].macUUID === macUUID) {
+        if(macConfigs[key].macAddonUUID === macAddonUUID) {
           return key.replace(/^firefox-container-@@_/, "");
         }
       }
@@ -91,7 +91,7 @@ const identityState = {
   _createIdentityState() {
     return {
       hiddenTabs: [],
-      macUUID: uuidv4()
+      macAddonUUID: uuidv4()
     };
   },
 };

--- a/src/js/background/identityState.js
+++ b/src/js/background/identityState.js
@@ -67,12 +67,17 @@ const identityState = {
 
     return this.storageArea.set(cookieStoreId, containerState);
   },
+
   async updateUUID(cookieStoreId, uuid) {
-    const containerState = await this.storageArea.get(cookieStoreId);
-    containerState.macAddonUUID = uuid;
-    await this.storageArea.set(cookieStoreId, containerState);
-    return;
+    if (cookieStoreId && uuid) {
+      const containerState = await this.storageArea.get(cookieStoreId);
+      containerState.macAddonUUID = uuid;
+      await this.storageArea.set(cookieStoreId, containerState);
+      return;
+    } 
+    throw new Error ("cookieStoreId or uuid missing");
   },
+
   async addUUID(cookieStoreId) {
     return await this.updateUUID(cookieStoreId, uuidv4());
   },

--- a/src/js/background/identityState.js
+++ b/src/js/background/identityState.js
@@ -76,6 +76,20 @@ const identityState = {
     return this.updateUUID(cookieStoreId, uuidv4());
   },
 
+  async lookupCookieStoreId(macUUID) {
+    console.log("luCSI");
+    const macConfigs = await this.storageArea.area.get();
+    for(const key of Object.keys(macConfigs)) {
+      if (key.includes("identitiesState@@_")) {
+        if(macConfigs[key].macUUID === macUUID) {
+          console.log(key);
+          return key.replace(/^firefox-container-@@_/, "");
+        }
+      }
+    }
+    return false;
+  },
+
   _createIdentityState() {
     return {
       hiddenTabs: [],

--- a/src/js/background/identityState.js
+++ b/src/js/background/identityState.js
@@ -38,7 +38,7 @@ const identityState = {
         if (configKey.includes("identitiesState@@_")) {
           const cookieStoreId = String(configKey).replace(/^identitiesState@@_/, "");
           const match = identitiesList.find(localIdentity => localIdentity.cookieStoreId === cookieStoreId);
-          if (!match) {
+          if (!match && cookieStoreId !== "firefox-default") {
             console.log("removed ", cookieStoreId, " from storage list");
             this.remove(cookieStoreId);
           }

--- a/src/js/background/identityState.js
+++ b/src/js/background/identityState.js
@@ -40,10 +40,10 @@ const identityState = {
   async getCookieStoreIDuuidMap() {
     const containers = {};
     const containerInfo = await identityState.storageArea.area.get();
-    for(const key of Object.keys(containerInfo)) {
-      if (key.includes("identitiesState@@_")) {
-        const container = containerInfo[key];
-        const cookieStoreId = key.replace(/^identitiesState@@_/, "");
+    for(const configKey of Object.keys(containerInfo)) {
+      if (configKey.includes("identitiesState@@_")) {
+        const container = containerInfo[configKey];
+        const cookieStoreId = configKey.replace(/^identitiesState@@_/, "");
         containers[cookieStoreId] = container.macAddonUUID;
       }
     }
@@ -79,10 +79,10 @@ const identityState = {
 
   async lookupMACaddonUUID(cookieStoreId) {
     const macConfigs = await this.storageArea.area.get();
-    for(const key of Object.keys(macConfigs)) {
-      if (key.includes("identitiesState@@_")) {
-        if(macConfigs[key] === cookieStoreId) {
-          return macConfigs[key].macAddonUUID;
+    for(const configKey of Object.keys(macConfigs)) {
+      if (configKey.includes("identitiesState@@_")) {
+        if(macConfigs[configKey] === cookieStoreId) {
+          return macConfigs[configKey].macAddonUUID;
         }
       }
     }
@@ -91,10 +91,10 @@ const identityState = {
 
   async lookupCookieStoreId(macAddonUUID) {
     const macConfigs = await this.storageArea.area.get();
-    for(const key of Object.keys(macConfigs)) {
-      if (key.includes("identitiesState@@_")) {
-        if(macConfigs[key].macAddonUUID === macAddonUUID) {
-          return String(key).replace(/^identitiesState@@_/, "");
+    for(const configKey of Object.keys(macConfigs)) {
+      if (configKey.includes("identitiesState@@_")) {
+        if(macConfigs[configKey].macAddonUUID === macAddonUUID) {
+          return String(configKey).replace(/^identitiesState@@_/, "");
         }
       }
     }


### PR DESCRIPTION
## Steps to test:

Test for first install or update of new MAC with sync:
1. Pull and load as temporary extension (on a new profile probably?)
2. Add one container to your default four
3. in extension console, run `browser.resetMAC1()`
   This adds a few configs to your `browser.storage.local` to setup with some default MAC configs
4. reload extension
   This shows the first sync upon install/update
5. Info backed up in sync is listed in console.
6. Reload again to see what would happen if data is the same as synced data in pre-synced MAC

Next test for syncing with 2nd version of FF/MAC:
1. in extension console run `browser.resetMac2()`
2. If you want, see that some icons have changed color and some containers have changed assignments.
3. reload extension to see what will happen when 2nd browser with MAC previously installed and configured is synced.
4. See that icons have changed back and new site assignments have been added.
5. Rejoice (hopefully)
6. Give lots of feedback on how to make this better

Test for syncing based on UUID after browser has already been synced once
1. add a new container or uncomment the line in resetMAC3 that does it for you
2. run `browser.resetMAC3()` then reload the extension to see the behavoir

## Notes:

 * Doesn't pass tests due to linter (console.logs), and it passes the other tests, ~~but in ugly ways, so that needs to be fixed.~~
 * `resetMac1()` and `resetMac1()` should be made into mocha tests, probably.
 * If there is a mismatch in container that a site is assigned to in addon vs. sync, the user will need to be notified to make a choice. That is not implemented yet.
 * ~~There is at least a 3rd path that still needs to be written: When MAC has been synced before. This should be more straight forward using the new macUUID to keep everything straight.~~
 * ~~container/site assignment deletion has not yet been tacked.~~
* the initial syncs (from 2 pre-existing MAC addons) are still a little wonky--you usually end up with double of everything.


Thanks!