### PR TITLE
Implement container reordering

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -691,6 +691,10 @@ h3.title {
   max-inline-size: 300px;
 }
 
+.menu-item.drag-over td {
+  border-block-start: 2px solid var(--text-normal-color);
+}
+
 .disabled-menu-item {
   color: grey;
   cursor: default;
@@ -930,6 +934,22 @@ tr > td > .trash-button {
 
 tr:hover > td > .trash-button {
   display: block;
+}
+
+.move-button {
+  cursor: move;
+  display: inline-block;
+  height: 100%;
+  inline-size: 16px;
+  margin-block-end: 4px;
+  margin-block-start: 4px;
+  margin-inline-end: 10px;
+  margin-inline-start: auto;
+  text-align: center;
+}
+
+.move-button > img {
+  height: 16px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/img/container-move.svg
+++ b/src/img/container-move.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><script xmlns=""/>
+    <defs/>
+    <g id="All" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="hamburger-menu" fill="#858585">
+            <g id="Group" transform="translate(2.000000, 6.000000)">
+                <rect id="Rectangle-path" x="0" y="0" width="26" height="2"/>
+                <rect id="Rectangle-path" x="0" y="8" width="26" height="2"/>
+                <rect id="Rectangle-path" x="0" y="16" width="26" height="2"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -10,6 +10,8 @@ const DEFAULT_ICON = "circle";
 const NEW_CONTAINER_ID = "new";
 
 const ONBOARDING_STORAGE_KEY = "onboarding-stage";
+const CONTAINER_ORDER_STORAGE_KEY = "container-order";
+const CONTAINER_DRAG_DATA_TYPE = "firefox-container";
 
 // List of panels
 const P_ONBOARDING_1 = "onboarding1";
@@ -192,16 +194,29 @@ const Logic = {
     elementToEnable.classList.remove("disabled-menu-item");
   },
 
+  async saveContainerOrder(rows) {
+    const containerOrder = {};
+    rows.forEach((node, index) => {
+      return containerOrder[node.dataset.containerId] = index;
+    });
+    await browser.storage.local.set({
+      [CONTAINER_ORDER_STORAGE_KEY]: containerOrder
+    });
+  },
+
   async refreshIdentities() {
-    const [identities, state] = await Promise.all([
+    const [identities, state, containerOrderStorage] = await Promise.all([
       browser.contextualIdentities.query({}),
       browser.runtime.sendMessage({
         method: "queryIdentitiesState",
         message: {
           windowId: browser.windows.WINDOW_ID_CURRENT
         }
-      })
+      }),
+      browser.storage.local.get([CONTAINER_ORDER_STORAGE_KEY])
     ]);
+    const containerOrder =
+      containerOrderStorage && containerOrderStorage[CONTAINER_ORDER_STORAGE_KEY];
     this._identities = identities.map((identity) => {
       const stateObject = state[identity.cookieStoreId];
       if (stateObject) {
@@ -211,8 +226,11 @@ const Logic = {
         identity.numberOfOpenTabs = stateObject.numberOfOpenTabs;
         identity.isIsolated = stateObject.isIsolated;
       }
+      if (containerOrder) {
+        identity.order = containerOrder[identity.cookieStoreId];
+      }
       return identity;
-    });
+    }).sort((i1, i2) => i1.order - i2.order);
   },
 
   getPanelSelector(panel) {
@@ -1006,11 +1024,58 @@ Logic.registerPanel(MANAGE_CONTAINERS_PICKER, {
             data-identity-color="${identity.color}">
           </div>
         </div>
-        <span class="menu-text">${identity.name}</span>`;
+        <span class="menu-text">${identity.name}</span>
+        <span class="move-button">
+          <img
+            class="pop-button-image"
+            src="/img/container-move.svg"
+          />
+        </span>`;
 
       fragment.appendChild(tr);
 
       tr.appendChild(td);
+
+      tr.draggable = true;
+      tr.dataset.containerId = identity.cookieStoreId;
+      tr.addEventListener("dragstart", (e) => {
+        e.dataTransfer.setData(CONTAINER_DRAG_DATA_TYPE, identity.cookieStoreId);
+      });
+      tr.addEventListener("dragover", (e) => {
+        if (e.dataTransfer.types.includes(CONTAINER_DRAG_DATA_TYPE)) {
+          tr.classList.add("drag-over");
+          e.preventDefault();
+        }
+      });
+      tr.addEventListener("dragenter", (e) => {
+        if (e.dataTransfer.types.includes(CONTAINER_DRAG_DATA_TYPE)) {
+          e.preventDefault();
+          tr.classList.add("drag-over");
+        }
+      });
+      tr.addEventListener("dragleave", (e) => {
+        if (e.dataTransfer.types.includes(CONTAINER_DRAG_DATA_TYPE)) {
+          e.preventDefault();
+          tr.classList.remove("drag-over");
+        }
+      });
+      tr.addEventListener("drop", async (e) => {
+        e.preventDefault();
+        const parent = tr.parentNode;
+        const containerId = e.dataTransfer.getData(CONTAINER_DRAG_DATA_TYPE);
+        let droppedElement;
+        parent.childNodes.forEach((node) => {
+          if (node.dataset.containerId === containerId) {
+            droppedElement = node;
+          }
+        });
+        if (droppedElement && droppedElement !== tr) {
+          tr.classList.remove("drag-over");
+          parent.insertBefore(droppedElement, tr);
+          await Logic.saveContainerOrder(parent.childNodes);
+          await Logic.refreshIdentities();
+        }
+      });
 
       Utils.addEnterHandler(tr, () => {
         pickedFunction(identity);


### PR DESCRIPTION
This is just a small patch that makes it possible to move / reorder containers via drag&drop. 

I added a third button next to the edit (pencil) button that allows users to drag a container and insert it before another container. Container positions are saved in the browser's local storage.

I got the icon from the [Mozilla Foundation Icon Font](https://mozilla.github.io/foundation-icons/).

Related issue: #330 

Example:

![firefox-container-reordering](https://user-images.githubusercontent.com/4525736/71443156-941d8780-2733-11ea-952a-ba8e3a1b0b3c.gif)

[firefox_multi-account_containers-6.1.1.zip](https://github.com/mozilla/multi-account-containers/files/4007793/firefox_multi-account_containers-6.1.1.zip)

