### PR TITLE
Add feature to edit websites that open automatically in a certain container

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -975,6 +975,30 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       Logic.showPreviousPanel();
     });
 
+    Logic.addEnterHandler(document.querySelector("#website-add-link"), () => {
+      const sitesList = document.querySelector(".assigned-sites-list");
+      const trElement = document.createElement("div");
+      trElement.innerHTML = escaped`
+      <div class="truncated-text hostname">
+        <input id="site-editor" />
+      </div>`;
+      trElement.classList.add("container-info-tab-row");
+      Logic.addEnterHandler(trElement.querySelector("#site-editor"), async (e) => {
+        let newurl = e.target.value;
+        if (!newurl.startsWith("http:") && !newurl.startsWith("https:")) {
+          newurl = "https://" + newurl;
+        }
+        const userContextId = Logic.currentUserContextId();
+        const currentTab = await Logic.currentTab();
+        const assignments = await Logic.getAssignmentObjectByContainer(userContextId);
+        Logic.setOrRemoveAssignment(currentTab.id, newurl, userContextId, false);
+        assignments["siteContainerMap@@_" + e.target.value] = {hostname: e.target.value};
+        this.showAssignedContainers(assignments);
+      });
+      sitesList.appendChild(trElement);
+      trElement.querySelector("#site-editor").focus();
+    });
+
     this._editForm = document.getElementById("edit-container-panel-form");
     const editLink = document.querySelector("#edit-container-ok-link");
     Logic.addEnterHandler(editLink, () => {
@@ -1014,7 +1038,8 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
   showAssignedContainers(assignments) {
     const assignmentPanel = document.getElementById("edit-sites-assigned");
     const assignmentKeys = Object.keys(assignments);
-    assignmentPanel.hidden = !(assignmentKeys.length > 0);
+    const userContextId = Logic.currentUserContextId();
+    assignmentPanel.hidden = !userContextId;
     if (assignments) {
       const tableElement = assignmentPanel.querySelector(".assigned-sites-list");
       /* Remove previous assignment list,
@@ -1093,7 +1118,6 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     const assignments = await Logic.getAssignmentObjectByContainer(userContextId);
     this.showAssignedContainers(assignments);
     document.querySelector("#edit-container-panel .panel-footer").hidden = !!userContextId;
-
     document.querySelector("#edit-container-panel-name-input").value = identity.name || "";
     document.querySelector("#edit-container-panel-usercontext-input").value = userContextId || NEW_CONTAINER_ID;
     const containerName = document.querySelector("#edit-container-panel-name-input");

--- a/src/popup.html
+++ b/src/popup.html
@@ -186,7 +186,12 @@
           </fieldset>
         </form>
         <div id="edit-sites-assigned" class="scrollable" hidden>
-          <h3>Sites assigned to this container</h3>
+          <h3>
+            Sites assigned to this container
+            <a href="#" tabindex="0" class="add-website-link" style="float: right;" id="website-add-link" title="Create new website">
+              <img class="pop-button-image-small icon" alt="Create new website icon" src="/img/container-add.svg" />
+            </a>
+          </h3>
           <div class="assigned-sites-list">
           </div>
         </div>


### PR DESCRIPTION
## Changes
* "Sites assigned to open in this container" is always visible, even if there are no sites assigned. However, this does not show when creating a new container.
* Added "+" icon on the side of the title, which creates a new input to add a website.

## Behavior
If the user types the URL "cnn.com", `https://` is added, but not `www`
If the user types the URL "http://cnn.com", nothing is added
If the user types the URL "www.cnn.com", `https://` is added, but not `www`
If the user types the URL "https://cnn.com", nothing is added

This was created out of personal need, but I feel that it could be useful to everyone to have. This is especially useful when the URL you want to add instantly redirects to another URL when it is typed in the omnibox (which you cannot do with the checkbox currently.)

I notice that #1613 also implements similar features, but takes a different approach. This is easier for power users because you do not have to _open_ the website in the container.