### PR TITLE
Fix for #1632: Pinned tabs cannot be loaded as 'discarded'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testpilot-containers",
   "title": "Multi-Account Containers",
   "description": "Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "author": "Andrea Marchesini, Luke Crouch and Jonathan Kingston",
   "bugs": {
     "url": "https://github.com/mozilla/multi-account-containers/issues"

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -310,12 +310,13 @@ const backgroundLogic = {
 
     for (let object of containerState.hiddenTabs) { // eslint-disable-line prefer-const
       // do not show already opened url
+      const noload = !object.pinned;
       if (object.url !== options.alreadyShowingUrl) {
         promises.push(this.openNewTab({
           userContextId: userContextId,
           url: object.url,
           nofocus: options.nofocus || false,
-          noload: true,
+          noload: noload,
           pinned: object.pinned,
         }));
       }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Multi-Account Containers",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "incognito": "not_allowed",
   "description": "Multi-Account Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
   "icons": {


### PR DESCRIPTION
Turns out pinned tabs cannot be loaded as `discarded`

## Steps to Test:

1. Pin container tab
2. Hide the container
3. Unhide the container
4. See pinned tab reappear as pinned tab instead of nothing happening

easy peasy

It still opens other (non-pinned) hidden tabs as 'discarded' so they do not load all at once when unhiding.