### PR TITLE
Fixes #1231 confirmation page alignment

### DIFF
--- a/src/css/confirm-page.css
+++ b/src/css/confirm-page.css
@@ -77,6 +77,10 @@ dfn {
   font-style: normal;
 }
 
+#deny, #confirm {
+  flex-grow: 1;
+}
+
 .button-container > button {
   min-inline-size: 240px;
 }

--- a/src/css/confirm-page.css
+++ b/src/css/confirm-page.css
@@ -28,7 +28,7 @@ button .container-name,
 
   /* for a mid sized window we have enough for this but not our image */
   .title {
-    background-image: url("chrome://global/skin/icons/info.svg");
+    background-image: url('chrome://global/skin/icons/info.svg');
   }
 }
 
@@ -77,7 +77,8 @@ dfn {
   font-style: normal;
 }
 
-#deny, #confirm {
+#deny,
+#confirm {
   flex-grow: 1;
 }
 


### PR DESCRIPTION
Fixes issue #1231 confirmation page alignment

Before:
<img width="479" alt="image" src="https://user-images.githubusercontent.com/25093613/76660069-71d72100-654e-11ea-9c94-154ec071246b.png">

After:
<img width="478" alt="image" src="https://user-images.githubusercontent.com/25093613/76660016-54a25280-654e-11ea-92c0-546d8d09c165.png">
