### PR TITLE
Fixes #1682 'open in current container button' not working

### DIFF
--- a/src/js/confirm-page.js
+++ b/src/js/confirm-page.js
@@ -17,25 +17,14 @@ async function load() {
     const currentContainer = await browser.contextualIdentities.get(currentCookieStoreId);
     document.getElementById("current-container-name").textContent = currentContainer.name;
   }
-
-  document.getElementById("redirect-form").addEventListener("submit", (e) => {
+  document.getElementById("deny").addEventListener("click", (e) => {
     e.preventDefault();
-    let button = "confirm"; // Confirm is the form default.
-    let buttonTarget = e.explicitOriginalTarget;
-    if (buttonTarget.tagName !== "BUTTON") {
-      buttonTarget = buttonTarget.closest("button");
-    }
-    if (buttonTarget && buttonTarget.id) {
-      button = buttonTarget.id;
-    }
-    switch (button) {
-    case "deny":
-      denySubmit(redirectUrl);
-      break;
-    case "confirm":
-      confirmSubmit(redirectUrl, cookieStoreId);
-      break;
-    }
+    denySubmit(redirectUrl);
+  });
+
+  document.getElementById("confirm").addEventListener("click", (e) => {
+    e.preventDefault();
+    confirmSubmit(redirectUrl, cookieStoreId);
   });
 }
 


### PR DESCRIPTION
Fixes the 'open in current container button' on the confirmation page. It would always default to using the assigned container instead.  

I am not sure what exactly broke it, but [Event.explicitOriginalTarget](https://developer.mozilla.org/en-US/docs/Web/API/Event/explicitOriginalTarget) is non standard according to MDN. So assigning to separate handlers should be preferable anyway imo.  

I looked into writing test cases for this since according to #1682 this broke before but I could not get the confirmation page working in jsdom.