### PR TITLE
Fixes #1670 Manually add URL's to a container

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -951,6 +951,20 @@ span ~ .panel-header-text {
   padding-block-start: 5px;
   padding-inline-end: 5px;
   padding-inline-start: 5px;
+
+}
+
+.edit-container-panel input[type="text"]#edit-container-panel-site-input {
+  inline-size: 80%;
+}
+
+#edit-container-site-link {
+  block-size: 36px;
+  background: #ebebeb;
+}
+
+#edit-container-site-link:hover {
+  background: #e3e3e3;
 }
 
 .edit-container-panel legend {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -951,7 +951,6 @@ span ~ .panel-header-text {
   padding-block-start: 5px;
   padding-inline-end: 5px;
   padding-inline-start: 5px;
-
 }
 
 .edit-container-panel input[type="text"]#edit-container-panel-site-input {
@@ -959,8 +958,8 @@ span ~ .panel-header-text {
 }
 
 #edit-container-site-link {
-  block-size: 36px;
   background: #ebebeb;
+  block-size: 36px;
 }
 
 #edit-container-site-link:hover {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1054,6 +1054,11 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       this._submitForm();
     });
 
+    // Add new site to current container
+    const siteLink = document.querySelector("#edit-container-site-link");
+    Logic.addEnterHandler(siteLink, () => {
+      this._addSite();
+    });
 
   },
 
@@ -1076,6 +1081,12 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     } catch (e) {
       Logic.showPanel(P_CONTAINERS_LIST);
     }
+  },
+
+  async _addSite() {
+    const formValues = new FormData(this._editForm);
+    console.log(formValues.get("container-id"));
+    console.log(formValues.get("site-name"));
   },
 
   showAssignedContainers(assignments) {
@@ -1161,6 +1172,8 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     const assignments = await Logic.getAssignmentObjectByContainer(userContextId);
     this.showAssignedContainers(assignments);
     document.querySelector("#edit-container-panel .panel-footer").hidden = !!userContextId;
+    // Only show ability to add site if it's an existing container
+    document.querySelector("#edit-container-panel-add-site").hidden = !userContextId;
 
     document.querySelector("#edit-container-panel-name-input").value = identity.name || "";
     document.querySelector("#edit-container-panel-usercontext-input").value = userContextId || NEW_CONTAINER_ID;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1106,27 +1106,22 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
   },
 
   checkUrl(url){
-    // append "https://" if protocol not found
     const validUrl = /[\w.-]+(?:\.[\w.-]+)/g;
-    const regexWww = /.*www\..*/g;
-    const regexhttp = /^http:\/\/.*/g;
-    const regexhttps = /^https:\/\/.*/g;
+    const regexProtocol = /^https?:\/\/.*/g;
+    const valid = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www\.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w\-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[.!/\\\w]*))?)/g;
     let newURL = url;
     
     if (!url.match(validUrl)) {
       return null;
     }
 
-    if (!url.match(regexhttp) && !url.match(regexhttps)) {
+    // append "https://" if protocol not found
+    if (!url.match(regexProtocol)) {
       newURL = "https://" + url;
     }
 
-    if (!url.match(regexWww)) {
-      if (newURL.match(regexhttp)) {
-        newURL = "http://www." + newURL.substring(7);
-      } else if (newURL.match(regexhttps)) {
-        newURL = "https://www." + newURL.substring(8);
-      }
+    if (!newURL.match(valid)) {
+      return null;
     }
     return newURL;
   },

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1092,32 +1092,36 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     const tabId = currentTab.id;
     const fullURL = this.checkUrl(url);
 
-    // Assign URL to container
-    await Logic.setOrRemoveAssignment(tabId, fullURL, userContextId, false);
+    if (fullURL !== null) { 
+      // Assign URL to container
+      await Logic.setOrRemoveAssignment(tabId, fullURL, userContextId, false);
 
-    // Clear form
-    document.querySelector("#edit-container-panel-site-input").value = "";
+      // Clear form
+      document.querySelector("#edit-container-panel-site-input").value = "";
 
-    // Show new assignments
-    const assignments = await Logic.getAssignmentObjectByContainer(userContextId);
-    this.showAssignedContainers(assignments);
+      // Show new assignments
+      const assignments = await Logic.getAssignmentObjectByContainer(userContextId);
+      this.showAssignedContainers(assignments); 
+    }
   },
 
   checkUrl(url){
     // append "https://" if protocol not found
+    const validUrl = /[\w.-]+(?:\.[\w.-]+)/g;
     const regexWww = /.*www\..*/g;
-    const foundWww = url.match(regexWww);
     const regexhttp = /^http:\/\/.*/g;
     const regexhttps = /^https:\/\/.*/g;
-    const foundhttp = url.match(regexhttp);
-    const foundhttps = url.match(regexhttps);
     let newURL = url;
+    
+    if (!url.match(validUrl)) {
+      return null;
+    }
 
-    if (!foundhttp && !foundhttps) {
+    if (!url.match(regexhttp) && !url.match(regexhttps)) {
       newURL = "https://" + url;
     }
 
-    if (!foundWww) {
+    if (!url.match(regexWww)) {
       if (newURL.match(regexhttp)) {
         newURL = "http://www." + newURL.substring(7);
       } else if (newURL.match(regexhttps)) {

--- a/src/popup.html
+++ b/src/popup.html
@@ -204,6 +204,11 @@
           <fieldset id="edit-container-panel-choose-icon" class="radio-choice">
             <legend>Choose an icon</legend>
           </fieldset>
+          <fieldset id="edit-container-panel-add-site" hidden>
+            <legend>Assign site</legend>
+            <input type="text" name="site-name" id="edit-container-panel-site-input"/>
+            <a class="button secondary" id="edit-container-site-link">Add</a>
+          </fieldset>
         </form>
         <div id="edit-sites-assigned" class="scrollable" hidden>
           <h3>Sites assigned to this container</h3>

--- a/test/issues/1670.test.js
+++ b/test/issues/1670.test.js
@@ -1,0 +1,81 @@
+// const expect = require("chai").expect;
+const {initializeWithTab} = require("../common");
+
+describe("#1670", function () {
+  beforeEach(async function () {
+    this.webExt = await initializeWithTab();
+  });
+
+  afterEach(function () {
+    this.webExt.destroy();
+  });
+
+  describe("creating a new container", function () {
+    beforeEach(async function () {
+      await this.webExt.popup.helper.clickElementById("container-add-link");
+      await this.webExt.popup.helper.clickElementById("edit-container-ok-link");
+    });
+
+    it("should create it in the browser as well", function () {
+      this.webExt.background.browser.contextualIdentities.create.should.have.been.calledOnce;
+    });
+
+    describe("manually assign a valid URL to a container", function () {
+      const exampleUrl = "https://github.com/mozilla/multi-account-containers";
+      beforeEach(async function () {
+        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+      });
+
+      it("should assign the URL to a container", function () {
+        this.webExt.background.browser.contextualIdentities.create.should.have.been.calledOnce;
+      });
+    });
+
+    describe("manually assign valid URL without protocol to a container", function () {
+      const exampleUrl = "github.com/mozilla/multi-account-containers";
+      beforeEach(async function () {
+        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+      });
+
+      it("should assign the URL without protocol to a container", function () {
+        this.webExt.background.browser.contextualIdentities.create.should.have.been.calledOnce;
+      });
+    });
+
+    describe("manually assign an invalid URL to a container", function () {
+      const exampleUrl = "github";
+      beforeEach(async function () {
+        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+      });
+
+      it("should not assign the URL to a container", function () {
+        // console.log(this.webExt.background.browser.contextualIdentities);
+        // expect( console.log.calledOnce ).to.be.true;
+        this.webExt.background.browser.contextualIdentities.update.should.not.have.been.called;
+      });
+    });
+
+    describe("manually assign empty URL to a container", function () {
+      const exampleUrl = "";
+      beforeEach(async function () {
+        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+      });
+
+      it("should not assign the URL to a container", function () {
+        this.webExt.background.browser.contextualIdentities.update.should.not.have.been.called;
+      });
+    });
+  });
+});

--- a/test/issues/1670.test.js
+++ b/test/issues/1670.test.js
@@ -1,4 +1,3 @@
-// const expect = require("chai").expect;
 const {initializeWithTab} = require("../common");
 
 describe("#1670", function () {
@@ -58,8 +57,6 @@ describe("#1670", function () {
       });
 
       it("should not assign the URL to a container", function () {
-        // console.log(this.webExt.background.browser.contextualIdentities);
-        // expect( console.log.calledOnce ).to.be.true;
         this.webExt.background.browser.contextualIdentities.update.should.not.have.been.called;
       });
     });


### PR DESCRIPTION
Fixes the issues #1670 Manually add URL's to a container

**Implemented**:
- Added an input field in the "edit container" menu of each container
- Added URL will show immediately once added
- If the input URL already register to another container, the URL will add to the current one and remove from the previously registered container

**Demonstration**:
![ezgif com-optimize](https://user-images.githubusercontent.com/23732578/76789174-acc99680-6792-11ea-9953-c9574f4b5c89.gif)
