### PR TITLE
Issue 1607 Feature Request: Reorganize windows (not just tabs) by category

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -486,28 +486,28 @@ manage things like container crud */
 
 .container-panel-controls {
   display: flex;
-  justify-content: flex-end;
   margin-block-end: var(--block-line-space-size);
   margin-block-start: var(--block-line-space-size);
-  margin-inline-end: var(--inline-item-space-size);
-  margin-inline-start: var(--inline-item-space-size);
 }
 
-#container-panel #sort-containers-link {
+#container-panel .sort-link {
   align-items: center;
   block-size: var(--block-url-label-size);
   border: 1px solid #d8d8d8;
   border-radius: var(--small-radius);
   color: var(--title-text-color);
   display: flex;
+  flex-grow: 1;
   font-size: var(--small-text-size);
   inline-size: var(--inline-button-size);
   justify-content: center;
+  margin-left: var(--block-line-space-size);
+  margin-right: var(--block-line-space-size);
   text-decoration: none;
 }
 
-#container-panel #sort-containers-link:hover,
-#container-panel #sort-containers-link:focus {
+#container-panel .sort-link:hover,
+#container-panel .sort-link:focus {
   background: #f2f2f2;
 }
 

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -238,7 +238,7 @@ const backgroundLogic = {
   },
 
   async sortTabsByWindow() {
-    let windows = await browser.windows.getAll();
+    const windows = await browser.windows.getAll();
     let containers = new Set();
 
     // loop through each tab to find all active containers
@@ -257,13 +257,6 @@ const backgroundLogic = {
       await this._sortTabsByWindowInternal(windowId, containers[i]);
     }
 
-    // Logically, there shouldn't be any redundant windows
-    // but, maybe other addons/features conflicts, so double check to
-    // delete redundant windows here.
-    windows = await browser.windows.getAll();
-    for (let i = containers.length; i < windows.length; i++) {
-      await browser.windows.remove(windows[i].id);
-    }
   },
 
   async _sortTabsByWindowInternal(windowId, cookieStoreId) {
@@ -276,11 +269,13 @@ const backgroundLogic = {
     if (windowId === -1) {
       const newWindowObj = await browser.windows.create();
       windowId = newWindowObj.id;
+      // Since creating new window will open a default tab,
+      // take the tab id here, and we could delete it after moving
       newlyOpenedTabId = newWindowObj.tabs[0].id;
     }
 
     // move all tabs
-    browser.tabs.move(tabs.map((tab) => tab.id), {
+    await browser.tabs.move(tabs.map((tab) => tab.id), {
       windowId: windowId,
       index: -1
     });

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -237,6 +237,61 @@ const backgroundLogic = {
     return identitiesOutput;
   },
 
+  async sortTabsByWindow() {
+    let windows = await browser.windows.getAll();
+    let containers = new Set();
+
+    // loop through each tab to find all active containers
+    for (const windowObj of windows) {
+      const tabs = await browser.tabs.query({windowId: windowObj.id});
+      for (const tab of tabs) {
+        containers.add(tab.cookieStoreId);
+      }
+    }
+    containers = Array.from(containers);
+
+    // for each container, move all related tabs to its window
+    for (let i = 0; i < containers.length; i++) {
+      // if no window is available, then pass -1
+      const windowId = (i < windows.length) ? windows[i].id : -1;
+      await this._sortTabsByWindowInternal(windowId, containers[i]);
+    }
+
+    // Logically, there shouldn't be any redundant windows
+    // but, maybe other addons/features conflicts, so double check to
+    // delete redundant windows here.
+    windows = await browser.windows.getAll();
+    for (let i = containers.length; i < windows.length; i++) {
+      await browser.windows.remove(windows[i].id);
+    }
+  },
+
+  async _sortTabsByWindowInternal(windowId, cookieStoreId) {
+    let newlyOpenedTabId = null;
+    const tabs = await browser.tabs.query({
+      "cookieStoreId": cookieStoreId
+    });
+
+    // create a new window so that move tabs to the new window
+    if (windowId === -1) {
+      const newWindowObj = await browser.windows.create();
+      windowId = newWindowObj.id;
+      newlyOpenedTabId = newWindowObj.tabs[0].id;
+    }
+
+    // move all tabs
+    browser.tabs.move(tabs.map((tab) => tab.id), {
+      windowId: windowId,
+      index: -1
+    });
+
+    // if new window is created, then close newly opened tab by its id
+    if (newlyOpenedTabId !== null) {
+      browser.tabs.remove(newlyOpenedTabId);
+    }
+
+  },
+
   async sortTabs() {
     const windows = await browser.windows.getAll();
     for (let windowObj of windows) { // eslint-disable-line prefer-const

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -40,6 +40,9 @@ const messageHandler = {
           return assignManager._setOrRemoveAssignment(tab.id, m.url, m.userContextId, m.value);
         });
         break;
+      case "sortTabsByWindow":
+        backgroundLogic.sortTabsByWindow();
+        break;
       case "sortTabs":
         backgroundLogic.sortTabs();
         break;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -599,6 +599,17 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       }
     });
 
+    Logic.addEnterHandler(document.querySelector("#sort-containers-link-window"), async () => {
+      try {
+        await browser.runtime.sendMessage({
+          method: "sortTabsByWindow"
+        });
+        window.close();
+      } catch (e) {
+        window.close();
+      }
+    });
+
     Logic.addEnterHandler(document.querySelector("#sort-containers-link"), async () => {
       try {
         await browser.runtime.sendMessage({

--- a/src/popup.html
+++ b/src/popup.html
@@ -128,7 +128,8 @@
       </label>
     </div>
     <div class="container-panel-controls">
-      <a href="#" class="action-link" id="sort-containers-link" title="Sort tabs into container order">Sort Tabs</a>
+      <a href="#" class="action-link sort-link" id="sort-containers-link-window" title="Sort tabs into container order by windows">Sort Tabs by Window</a>
+      <a href="#" class="action-link sort-link" id="sort-containers-link" title="Sort tabs into container order">Sort Tabs</a>
     </div>
     <div class="scrollable panel-content" tabindex="-1">
       <table class="identities-list">


### PR DESCRIPTION
Fixes the issues #1607 Feature Request: Reorganize windows (not just tabs) by category

**Implemented** 
- Added "Sort Tabs by Windows" button
- Added background logic for the Sort Tabs by Windows button
- Manually Test the features include edge case like (One window with different containers), (Multiple windows and different containers), (One window with different containers), (One window and one container).

**This is how the feature looks like now:** 
![](https://cdn.discordapp.com/attachments/681857035947737118/697159486867112026/issue-1607.gif)

