### PR TITLE
Changed IRC to Matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Everyone is welcome to contribute to containers. Reach out to team members if you have questions:
 
-- IRC: #containers on irc.mozilla.org
+- Matrix chat: #containers:mozilla.org
 - Email: containers@mozilla.com
 
 ## Filing bugs


### PR DESCRIPTION
replaced reference to IRC with reference to Matrix chat
not sure if that should be offered as a link via Riot for convenience, just making sure this PR exists so it gets updated either way :)