### PR TITLE
Remove automatic capitalization of container name

### DIFF
--- a/src/css/confirm-page.css
+++ b/src/css/confirm-page.css
@@ -18,7 +18,6 @@ main {
 button .container-name,
 #current-container-name {
   font-weight: bold;
-  text-transform: capitalize;
 }
 
 @media only screen and (max-width: 1300px) {


### PR DESCRIPTION
The name is not capitalized in the address bar or the list of names in the extension popup.

For example, one of my containers is "j...n@gmail" for my legacy Google account and it's awkward to see it capitalized as "J...n@gmail" in this single location.