### PR TITLE
Show fence icon in popup

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1274,7 +1274,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       return Utils.escaped`<input type="radio" value="${containerIcon}" name="container-icon" id="edit-container-panel-choose-icon-${containerIcon}" />
      <label for="edit-container-panel-choose-icon-${containerIcon}" class="usercontext-icon choose-color-icon" data-identity-color="grey" data-identity-icon="${containerIcon}">`;
     };
-    const icons = ["fingerprint", "briefcase", "dollar", "cart", "vacation", "gift", "food", "fruit", "pet", "tree", "chill", "circle"];
+    const icons = ["fingerprint", "briefcase", "dollar", "cart", "vacation", "gift", "food", "fruit", "pet", "tree", "chill", "circle", "fence"];
     const iconRadioFieldset = document.getElementById("edit-container-panel-choose-icon");
     icons.forEach((containerIcon) => {
       const templateInstance = document.createElement("div");


### PR DESCRIPTION
Fixes issue where Facebook container has no icon in popup. Also allows user to select fence icon for other containers.

Fixes https://github.com/mozilla/contain-facebook/issues/491
Relates to https://github.com/mozilla/contain-facebook/issues/205