### PR TITLE
Fixed #1779 - Added CSS override for favicons on the Manage Site List panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testpilot-containers",
   "title": "Multi-Account Containers",
   "description": "Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": "Andrea Marchesini, Luke Crouch and Jonathan Kingston",
   "bugs": {
     "url": "https://github.com/mozilla/multi-account-containers/issues"

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -721,6 +721,7 @@ h3.title {
 }
 
 /* Maintain 1:1 square ratio for Favicons of websites added to a specific container */
+#edit-sites-assigned .menu-icon,
 #container-info-table .menu-icon {
   inline-size: 16px;
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Multi-Account Containers",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "incognito": "not_allowed",
   "description": "Multi-Account Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
   "icons": {


### PR DESCRIPTION
_Note - This PR also bumps the version number._

Before: 
<img width="330" alt="image" src="https://user-images.githubusercontent.com/2692333/87087666-23364c80-c1f9-11ea-9c64-4ca1a87b070a.png">

After:
<img width="332" alt="image" src="https://user-images.githubusercontent.com/2692333/87087677-27626a00-c1f9-11ea-90fd-899877d6bd2f.png">
