### PR TITLE
Fixed #1810 - Split container item funcitonality

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -703,10 +703,14 @@ h3.title {
   color: #fff;
 }
 
-.menu-text {
+.menu-item-name {
+  display: flex;
   inline-size: calc(100% - 40px);
-  line-height: 24px;
   max-inline-size: 260px;
+}
+
+.menu-text {
+  line-height: 24px;
 }
 
 .menu-icon {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -403,6 +403,12 @@ const Logic = {
       if(element){
         element.click();
       }
+
+      // If one Container is highlighted,
+      if (element.classList.contains("keyboard-right-arrow-override")) {
+        element.querySelector(".menu-right-float").click();
+      }
+
       break;
     }
     case 37:
@@ -639,19 +645,21 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
 
     Logic.identities().forEach(identity => {
       const tr = document.createElement("tr");
-      tr.classList.add("menu-item", "hover-highlight", "keyboard-nav");
+      tr.classList.add("menu-item", "hover-highlight", "keyboard-nav", "keyboard-right-arrow-override");
       tr.setAttribute("tabindex", "0");
       const td = document.createElement("td");
       const openTabs = identity.numberOfOpenTabs || "" ;
 
-      td.innerHTML = Utils.escaped`          
-        <div class="menu-icon">
-          <div class="usercontext-icon"
-            data-identity-icon="${identity.icon}"
-            data-identity-color="${identity.color}">
+      td.innerHTML = Utils.escaped`
+        <div class="menu-item-name">
+          <div class="menu-icon">
+            <div class="usercontext-icon"
+              data-identity-icon="${identity.icon}"
+              data-identity-color="${identity.color}">
+            </div>
           </div>
+          <span class="menu-text">${identity.name}</span>
         </div>
-        <span class="menu-text">${identity.name}</span>
         <span class="menu-right-float">
           <span class="container-count">${openTabs}</span>
           <span class="menu-arrow">
@@ -663,9 +671,37 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
 
       tr.appendChild(td);
 
-      Utils.addEnterHandler(tr, () => {
+      const openInThisContainer = tr.querySelector(".menu-item-name");
+      Utils.addEnterHandler(openInThisContainer, () => {
+        try {
+          browser.tabs.create({
+            cookieStoreId: identity.cookieStoreId
+          });
+          window.close();
+        } catch (e) {
+          window.close();
+        }
+      });
+
+      Utils.addEnterOnlyHandler(tr, () => {
+        try {
+          browser.tabs.create({
+            cookieStoreId: identity.cookieStoreId
+          });
+          window.close();
+        } catch (e) {
+          window.close();
+        }
+      });
+
+      // Select only the ">" from the container list
+      const showPanelButton = tr.querySelector(".menu-right-float");
+
+      Utils.addEnterHandler(showPanelButton, () => {
         Logic.showPanel(P_CONTAINER_INFO, identity);
       });
+
+
     });
 
     const list = document.querySelector("#identities-list");

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -75,6 +75,15 @@ const Utils = {
     });
   },
 
+  addEnterOnlyHandler(element, handler) {
+    element.addEventListener("keydown", (e) => {
+      if (e.keyCode === 13) {
+        e.preventDefault();
+        handler(e);
+      }
+    });
+  },  
+
   userContextId(cookieStoreId = "") {
     const userContextId = cookieStoreId.replace("firefox-container-", "");
     return (userContextId !== cookieStoreId) ? Number(userContextId) : false;

--- a/src/popup.html
+++ b/src/popup.html
@@ -171,13 +171,14 @@
       <table class="menu" id="identities-list">
         <tr class="menu-item hover-highlight">
           <td>
-            <div class="menu-icon">
-              <div class="usercontext-icon"
-                data-identity-icon="pet"
-                data-identity-color="blue">
+            <div class="menu-item-name">
+              <div class="menu-icon">
+                <div class="usercontext-icon"
+                  data-identity-icon="pet"
+                  data-identity-color="blue"></div>
               </div>
+              <span class="menu-text">Default</span>
             </div>
-            <span class="menu-text">Default</span>
             <span class="menu-right-float">
               <span class="container-count">22</span>
               <span class="menu-arrow">


### PR DESCRIPTION
Expected: 

- Clicking on "Personal" Title/Icon should open new tab in PERSONAL container
<img width="111" alt="image" src="https://user-images.githubusercontent.com/2692333/87480083-3c247080-c5f2-11ea-81db-6d7dbad994b0.png">

- Clicking on ">" should open Personal container subpanel: 
<img width="333" alt="image" src="https://user-images.githubusercontent.com/2692333/87480158-5bbb9900-c5f2-11ea-9afd-c01cadba3b2b.png">

- Using keyboard navigation, arrow down to the Personal container item: 
  - On enter, a new tab in PERSONAL container should open
  - On right arrow, should open Personal container subpanel: 