### PR TITLE
Site isolation saved changes do not affect other containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testpilot-containers",
   "title": "Multi-Account Containers",
   "description": "Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "author": "Andrea Marchesini, Luke Crouch and Jonathan Kingston",
   "bugs": {
     "url": "https://github.com/mozilla/multi-account-containers/issues"

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -30,6 +30,13 @@ const P_CONTAINER_DELETE = "containerDelete";
 const P_CONTAINERS_ACHIEVEMENT = "containersAchievement";
 const P_CONTAINER_ASSIGNMENTS = "containerAssignments";
 
+function addRemoveSiteIsolation() {
+  const identity = Logic.currentIdentity();
+  browser.runtime.sendMessage({
+    method: "addRemoveSiteIsolation",
+    cookieStoreId: identity.cookieStoreId
+  });
+}
 
 async function getExtensionInfo() {
   const manifestPath = browser.extension.getURL("manifest.json");
@@ -1242,6 +1249,9 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
   initialize() {
     this.initializeRadioButtons();
     Utils.addEnterHandler(document.querySelector("#close-container-edit-panel"), () => {
+      // Resets listener from siteIsolation checkbox to keep the update queue to 0.
+      const siteIsolation = document.querySelector("#site-isolation");
+      siteIsolation.removeEventListener("change", addRemoveSiteIsolation, false);
       const formValues = new FormData(this._editForm);
       if (formValues.get("container-id") !== NEW_CONTAINER_ID) {
         this._submitForm();
@@ -1337,14 +1347,10 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       containerName.select();
       containerName.focus();
     });
+
     const siteIsolation = document.querySelector("#site-isolation");
     siteIsolation.checked = !!identity.isIsolated;
-    siteIsolation.addEventListener( "change", function() {
-      browser.runtime.sendMessage({ 
-        method: "addRemoveSiteIsolation",
-        cookieStoreId: identity.cookieStoreId
-      });
-    });
+    siteIsolation.addEventListener( "change", addRemoveSiteIsolation, false);
     [...document.querySelectorAll("[name='container-color']")].forEach(colorInput => {
       colorInput.checked = colorInput.value === identity.color;
     });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Multi-Account Containers",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "incognito": "not_allowed",
   "description": "Multi-Account Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
   "icons": {


### PR DESCRIPTION
Fixes #1781 

To verify:

1. Open panel, click "manage containers" 
1. Select first container, check box for Site isolation
1. Click < back button, select other container
1. check box for Site isolation in that container
1. Go back, select first container: 

Expected: Container checkbox is still checked. 

Run through the same test, except instead of going back, click out of panel and reopen/click "manage containers" 