### PR TITLE
Replace tab instead of creating a new one (#1765 #1704 #1590  #1837)

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -51,6 +51,11 @@ window.assignManager = {
       return !!syncEnabled;
     },
 
+    async getReplaceTabEnabled() {
+      const { replaceTabEnabled } = await browser.storage.local.get("replaceTabEnabled");
+      return !!replaceTabEnabled;
+    },
+
     getByUrlKey(siteStoreKey) {
       return new Promise((resolve, reject) => {
         this.area.get([siteStoreKey]).then((storageResponse) => {
@@ -233,9 +238,11 @@ window.assignManager = {
         return {};
       }
     }
+    const replaceTabEnabled = await this.storageArea.getReplaceTabEnabled();
     const removeTab = backgroundLogic.NEW_TAB_PAGES.has(tab.url)
       || (messageHandler.lastCreatedTab
-        && messageHandler.lastCreatedTab.id === tab.id);
+        && messageHandler.lastCreatedTab.id === tab.id)
+      || replaceTabEnabled;
     const openTabId = removeTab ? tab.openerTabId : tab.id;
 
     if (!this.canceledRequests[tab.id]) {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -28,14 +28,12 @@ async function enableDisableReplaceTab() {
 async function setupOptions() {
   const hasPermission = await browser.permissions.contains({permissions: ["bookmarks"]});
   const { syncEnabled } = await browser.storage.local.get("syncEnabled");
-  const { replaceTabEnabled } =
-    await browser.storage.local.get("replaceTabEnabled");
+  const { replaceTabEnabled } = await browser.storage.local.get("replaceTabEnabled");
   if (hasPermission) {
     document.querySelector("#bookmarksPermissions").checked = true;
   }
   document.querySelector("#syncCheck").checked = !!syncEnabled;
-  document.querySelector("#replaceTabCheck").checked =
-    !!replaceTabEnabled;
+  document.querySelector("#replaceTabCheck").checked = !!replaceTabEnabled;
   setupContainerShortcutSelects();
 }
 
@@ -83,8 +81,7 @@ function resetOnboarding() {
 document.addEventListener("DOMContentLoaded", setupOptions);
 document.querySelector("#bookmarksPermissions").addEventListener( "change", requestPermissions);
 document.querySelector("#syncCheck").addEventListener( "change", enableDisableSync);
-document.querySelector("#replaceTabCheck")
-  .addEventListener( "change", enableDisableReplaceTab);
+document.querySelector("#replaceTabCheck").addEventListener( "change", enableDisableReplaceTab);
 document.querySelector("button").addEventListener("click", resetOnboarding);
 
 for (let i=0; i < NUMBER_OF_KEYBOARD_SHORTCUTS; i++) {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -16,25 +16,26 @@ async function requestPermissions() {
 
 async function enableDisableSync() {
   const checkbox = document.querySelector("#syncCheck");
-  if (checkbox.checked) {
-    await browser.storage.local.set({syncEnabled: true});
-  } else {
-    await browser.storage.local.set({syncEnabled: false});
-  }
+  await browser.storage.local.set({syncEnabled: !!checkbox.checked});
   browser.runtime.sendMessage({ method: "resetSync" });
+}
+
+async function enableDisableReplaceTab() {
+  const checkbox = document.querySelector("#replaceTabCheck");
+  await browser.storage.local.set({replaceTabEnabled: !!checkbox.checked});
 }
 
 async function setupOptions() {
   const hasPermission = await browser.permissions.contains({permissions: ["bookmarks"]});
   const { syncEnabled } = await browser.storage.local.get("syncEnabled");
+  const { replaceTabEnabled } =
+    await browser.storage.local.get("replaceTabEnabled");
   if (hasPermission) {
     document.querySelector("#bookmarksPermissions").checked = true;
   }
-  if (syncEnabled) {
-    document.querySelector("#syncCheck").checked = true;
-  } else {
-    document.querySelector("#syncCheck").checked = false;
-  }
+  document.querySelector("#syncCheck").checked = !!syncEnabled;
+  document.querySelector("#replaceTabCheck").checked =
+    !!replaceTabEnabled;
   setupContainerShortcutSelects();
 }
 
@@ -82,6 +83,8 @@ function resetOnboarding() {
 document.addEventListener("DOMContentLoaded", setupOptions);
 document.querySelector("#bookmarksPermissions").addEventListener( "change", requestPermissions);
 document.querySelector("#syncCheck").addEventListener( "change", enableDisableSync);
+document.querySelector("#replaceTabCheck")
+  .addEventListener( "change", enableDisableReplaceTab);
 document.querySelector("button").addEventListener("click", resetOnboarding);
 
 for (let i=0; i < NUMBER_OF_KEYBOARD_SHORTCUTS; i++) {

--- a/src/options.html
+++ b/src/options.html
@@ -23,7 +23,7 @@
       <h3>Tab behaviour:</h3>
       <label>
         <input type="checkbox" id="replaceTabCheck">
-        Replace tab instead of new tab
+        Replace tab instead of creating a new one
       </label>
       <p><em>Replace the current tab if a page which is assigned to another container is opened (instead of keeping the current tab open).
         Opening tabs with middle mouse button is not affected.</em></p>

--- a/src/options.html
+++ b/src/options.html
@@ -23,9 +23,9 @@
       <h3>Tab behaviour:</h3>
       <label>
         <input type="checkbox" id="replaceTabCheck">
-        Enable tab replace for assigned domains
+        Replace tab instead of new tab
       </label>
-      <p><em>Replace current tab if a page which is assigned to a specific container is opened (instead of keeping the current tab open).
+      <p><em>Replace the current tab if a page which is assigned to another container is opened (instead of keeping the current tab open).
         Opening tabs with middle mouse button is not affected.</em></p>
       <h3>Keyboard Shortcuts:</h3>
       <p><em>Edit which container is opened when using the numbered shortcuts.</em></p>

--- a/src/options.html
+++ b/src/options.html
@@ -20,6 +20,13 @@
         Enable Sync
       </label>
       <p><em>This setting allows you to sync your containers and site assignments across devices.</em></p>
+      <h3>Tab behaviour:</h3>
+      <label>
+        <input type="checkbox" id="replaceTabCheck">
+        Enable tab replace for assigned domains
+      </label>
+      <p><em>Replace current tab if a page which is assigned to a specific container is opened (instead of keeping the current tab open).
+        Opening tabs with middle mouse button is not affected.</em></p>
       <h3>Keyboard Shortcuts:</h3>
       <p><em>Edit which container is opened when using the numbered shortcuts.</em></p>
       <p><label>

--- a/test/common.js
+++ b/test/common.js
@@ -87,7 +87,8 @@ const initializeWithTab = async (details = {
             "browserActionBadgesClicked": [],
             "onboarding-stage": 7,
             "achievements": [], 
-            "syncEnabled": true
+            "syncEnabled": true,
+            "replaceTabEnabled": false
           });
           window.browser.storage.local.set.resetHistory();
           window.browser.storage.sync.clear();


### PR DESCRIPTION
Adds an option in "Preferences" to replace the current tab if a page which is assigned to another container is opened instead of keeping the current tab open. Middle clicking is unaffected and always opens a new tab as before.

Related issues which should be solved by this: #1765 #1704 #1590 #1837