### PR TITLE
Fix breaking containers when adding tab with local file

### DIFF
--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -93,7 +93,8 @@ const backgroundLogic = {
     // We can't open these we just have to throw them away
     if (protocol === "about:"
         || protocol === "chrome:"
-        || protocol === "moz-extension:") {
+        || protocol === "moz-extension:"
+        || protocol === "file:") {
       return false;
     }
     return true;


### PR DESCRIPTION
See https://github.com/mozilla/multi-account-containers/issues/1717 for
a description of the underlying issue:

> Hide/Show tabs in this container actually closes and reopens tabs
> instead of hiding/showing, meaning it cannot reopen (show) privileged
> tabs (file, chrome, about, etc.)

This commit fixes #918 and #1817