### PR TITLE
Fix development instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,32 +18,43 @@ For more info, see:
 
 ## Development
 
-To run this extension:
+### Running Locally
 
-1. Open Firefox and load the `about:debugging` page. Click 
-   [Load Temporary Add-on](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox)
-   and select the `manifest.json` file within the folder of an example extension.
-   Here is a [video](https://www.youtube.com/watch?v=cer9EUKegG4)
-   that demonstrates how to do this.
-2. Install the
-   [web-ext](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext)
-   tool. At the command line, open the example extension's folder and type
-   `web-ext run -s src/`. This launches Firefox and installs the extension automatically.
-   This tool provides some additional development features, such as
-   [automatic reloading](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext#Automatic_extension_reloading).
+#### via WebExtensions API (web-ext)
+
+1. Install the [web-ext](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext) tool.
+2. Run `web-ext run -s src/`. This launches Firefox and installs the extension automatically.
+
+This tool provides some additional development features, such as [automatic reloading](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext#Automatic_extension_reloading).
+
+#### via about:debugging in Firefox
+
+1. Open the `about:debugging` page in Firefox.
+2. Click on `This FIrefox`.
+3. Click on [Load Temporary Add-on](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox).
+4. Select `src/manifest.json`.
+
+Here is a [video](https://www.youtube.com/watch?v=cer9EUKegG4) that demonstrates how to do this.
 
 ### Testing
 
-```
-# Install dependencies
-npm install
+* Install dependencies:
 
-# Run all tests
-npm run test
+  ```
+  npm install
+  ```
 
-# Only run the linter
-npm run lint
-```
+* Run all tests:
+
+  ```
+  npm run test
+  ```
+
+* Only run the linter:
+
+  ```
+  npm run lint
+  ```
 
 There is a timeout test that sometimes fails on certain machines, so make sure to run the tests on your clone before you make any changes to see if you have this problem.
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,32 @@ For more info, see:
 
 ## Development
 
-1. `npm install`
-2. `./node_modules/web-ext/bin/web-ext run -s src/`
+To run this extension:
+
+1. Open Firefox and load the `about:debugging` page. Click 
+   [Load Temporary Add-on](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox)
+   and select the `manifest.json` file within the folder of an example extension.
+   Here is a [video](https://www.youtube.com/watch?v=cer9EUKegG4)
+   that demonstrates how to do this.
+2. Install the
+   [web-ext](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext)
+   tool. At the command line, open the example extension's folder and type
+   `web-ext run -s src/`. This launches Firefox and installs the extension automatically.
+   This tool provides some additional development features, such as
+   [automatic reloading](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext#Automatic_extension_reloading).
 
 ### Testing
-`npm run test`
 
-or 
+```
+# Install dependencies
+npm install
 
-`npm run lint` 
+# Run all tests
+npm run test
 
-for just the linter
+# Only run the linter
+npm run lint
+```
 
 There is a timeout test that sometimes fails on certain machines, so make sure to run the tests on your clone before you make any changes to see if you have this problem.
 

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ For more info, see:
 
 ### Running Locally
 
-#### via WebExtensions API (web-ext)
+#### Via WebExtensions API (web-ext)
 
 1. Install the [web-ext](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext) tool.
 2. Run `web-ext run -s src/`. This launches Firefox and installs the extension automatically.
 
 This tool provides some additional development features, such as [automatic reloading](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext#Automatic_extension_reloading).
 
-#### via about:debugging in Firefox
+#### Via about:debugging in Firefox
 
 1. Open the `about:debugging` page in Firefox.
-2. Click on `This FIrefox`.
+2. Click on `This Firefox`.
 3. Click on [Load Temporary Add-on](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox).
 4. Select `src/manifest.json`.
 


### PR DESCRIPTION
web-ext will not work when following the instructions without having
this diff applied:

```
$ ./node_modules/web-ext/bin/web-ext run -s src/
(node:41062) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)
(node:41062) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
(node:41062) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
Applying config file: ./package.json
Running web extension from /home/andre/Git/multi-account-containers/src
Use --verbose or open Tools > Web Developer > Browser Console to see logging

WebExtError: Temporary add-on installation is not supported in this version of Firefox (you need Firefox 49 or higher). For older Firefox versions, use --pre-install
    at FirefoxDesktopExtensionRunner._callee6$ (/home/andre/Git/multi-account-containers/node_modules/web-ext/dist/webpack:/src/extension-runners/firefox-desktop.js:273:19)
    at tryCatch (/home/andre/Git/multi-account-containers/node_modules/web-ext/node_modules/regenerator-runtime/runtime.js:62:40)
    at Generator.invoke [as _invoke] (/home/andre/Git/multi-account-containers/node_modules/web-ext/node_modules/regenerator-runtime/runtime.js:296:22)
    at Generator.prototype.<computed> [as throw] (/home/andre/Git/multi-account-containers/node_modules/web-ext/node_modules/regenerator-runtime/runtime.js:114:21)
    at step (/home/andre/Git/multi-account-containers/node_modules/web-ext/dist/webpack:/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:1)
    at /home/andre/Git/multi-account-containers/node_modules/web-ext/dist/webpack:/node_modules/babel-runtime/helpers/asyncToGenerator.js:30:1
    at processTicksAndRejections (node:internal/process/task_queues:93:5)
```

web-ext will work when following the instructions with having this diff
applied:

```
$ web-ext run -s src/
Applying config file: ./package.json
Running web extension from /home/andre/Git/multi-account-containers/src
Use --verbose or open Tools > Web Developer > Browser Console to see logging
Installed /home/andre/Git/multi-account-containers/src as a temporary add-on
The extension will reload if any source file changes
Press R to reload (and Ctrl-C to quit)
```

I copied the wording from
https://github.com/mdn/webextensions-examples/blob/2184fee75afcde39328384b36adf9e52c5917949/README.md

I guess the underlying problem is that the web-ext version specified in
the package.json is very outdated. By installing the web-ext tool via
the provided instructions it fixes the problem.

Furthermore, the `webextensions-examples` repo doesn't specify web-ext
in their package.json which means that installing web-ext via the
provided instructions seems to be the preferred way. (So maybe web-ext
should be removed from the package.json entirely?)

Fixes #1926