### PR TITLE
Add a dark mode to MAC

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -64,7 +64,6 @@ body {
   --icon-fit: 8;
 }
 
-
 @media (min-resolution: 1dppx) {
   html {
     font-size: 14px;
@@ -939,55 +938,69 @@ tr:hover > td > .trash-button {
     --text-normal-color: #f9f9fa;
     --text-heading-color: #fff;
   }
+
   html {
     background-color: #4a4a4a;
   }
+
   body {
     color: #fff;
 
     --hr-grey: #38383d;
     --text-grey: #f9f9fa;
   }
+
   h3.title {
     color: #fff;
   }
+
   .bottom-btn {
     background-color: #737373;
     border: solid 1px #737373;
   }
+
   .btn-return.arrow-left {
     background-color: transparent;
   }
+
   .onboarding-title,
   .delete-container-confirm-title {
     color: #ededf0;
   }
+
   input {
     border: solid 1px #737373;
   }
+
   #edit-container-panel-name-input {
     background-color: #38383d;
     color: #fff;
   }
+
   .delete-container {
-  	background-color: #4a4a4a;
+    background-color: #4a4a4a;
   }
+
   .delete-btn {
     background-color: #737373;
     color: #f9f9fa;
   }
+
   .cancel-button,
   .grey-button {
     background-color: #737373;
     color: #fff;
   }
+
   .button.secondary:hover,
   .button.secondary:focus {
-  	background-color: #676767;
+    background-color: #676767;
   }
+
   .panel-footer {
     border-block-end: solid 1px #4a4a4a;
   }
+
   img.menu-icon,
   .menu-icon > img,
   .menu-arrow > img,
@@ -995,10 +1008,12 @@ tr:hover > td > .trash-button {
   .btn-return.arrow-left {
     filter: invert(1);
   }
+
   [data-identity-color="grey"] {
-  	--identity-icon-color: #ededf0;
+    --identity-icon-color: #ededf0;
   }
+
   [type="radio"]:checked + [data-identity-color="grey"] {
-  	--identity-icon-color: #616161;
+    --identity-icon-color: #616161;
   }
 }

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1015,8 +1015,8 @@ tr:hover > td > .trash-button {
   }
 
   .truncate-text::after {
-  	background: #4a4a4a;
-  	mask-image: linear-gradient(to right, transparent, #4a4a4a 70%);
+    background: #4a4a4a;
+    mask-image: linear-gradient(to right, transparent, #4a4a4a 70%);
   }
 
   [data-identity-color="grey"] {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -64,6 +64,7 @@ body {
   --icon-fit: 8;
 }
 
+
 @media (min-resolution: 1dppx) {
   html {
     font-size: 14px;
@@ -930,4 +931,74 @@ tr > td > .trash-button {
 
 tr:hover > td > .trash-button {
   display: block;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --title-text-color: #fff;
+    --text-normal-color: #f9f9fa;
+    --text-heading-color: #fff;
+  }
+  html {
+    background-color: #4a4a4a;
+  }
+  body {
+    color: #fff;
+
+    --hr-grey: #38383d;
+    --text-grey: #f9f9fa;
+  }
+  h3.title {
+    color: #fff;
+  }
+  .bottom-btn {
+    background-color: #737373;
+    border: solid 1px #737373;
+  }
+  .btn-return.arrow-left {
+    background-color: transparent;
+  }
+  .onboarding-title,
+  .delete-container-confirm-title {
+    color: #ededf0;
+  }
+  input {
+    border: solid 1px #737373;
+  }
+  #edit-container-panel-name-input {
+    background-color: #38383d;
+    color: #fff;
+  }
+  .delete-container {
+  	background-color: #4a4a4a;
+  }
+  .delete-btn {
+    background-color: #737373;
+    color: #f9f9fa;
+  }
+  .cancel-button,
+  .grey-button {
+    background-color: #737373;
+    color: #fff;
+  }
+  .button.secondary:hover,
+  .button.secondary:focus {
+  	background-color: #676767;
+  }
+  .panel-footer {
+    border-block-end: solid 1px #4a4a4a;
+  }
+  img.menu-icon,
+  .menu-icon > img,
+  .menu-arrow > img,
+  .info-icon > img,
+  .btn-return.arrow-left {
+    filter: invert(1);
+  }
+  [data-identity-color="grey"] {
+  	--identity-icon-color: #ededf0;
+  }
+  [type="radio"]:checked + [data-identity-color="grey"] {
+  	--identity-icon-color: #616161;
+  }
 }

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1009,6 +1009,16 @@ tr:hover > td > .trash-button {
     filter: invert(1);
   }
 
+  #edit-sites-assigned .menu-icon,
+  #container-info-table .menu-icon {
+    filter: invert(0);
+  }
+
+  .truncate-text::after {
+  	background: #4a4a4a;
+  	mask-image: linear-gradient(to right, transparent, #4a4a4a 70%);
+  }
+
   [data-identity-color="grey"] {
     --identity-icon-color: #ededf0;
   }


### PR DESCRIPTION
Hi,

As mentioned in #containers:mozilla.org, here's my patch to add a dark mode to MAC. Only the "Limit to designated sites" checkboxes aren't styled since checkbox elements aren't easily styleable without using `appearance: none`. 

Would it be acceptable to merge the patch as is or would you prefer if I also style the checkboxes? If you prefer the latter, we'll need an SVG for the checkbox mark icon.