### PR TITLE
Add option to disable the page action

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,7 +1,7 @@
 {
   "extensionDescription": {
-      "message": "Multi-Account Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
-      "description": "Description of the extension. DO NOT TRANSLATE \"Multi-Account Containers\"."
+    "message": "Multi-Account Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
+    "description": "Description of the extension. DO NOT TRANSLATE \"Multi-Account Containers\"."
   },
   "openInNewTabTitle": {
     "message": "Open New Tab in…",
@@ -27,10 +27,10 @@
     "message": "Always Open Site in Container"
   },
   "openANewTabIn": {
-    "message" : "Open a New Tab in…"
+    "message": "Open a New Tab in…"
   },
   "openNewTabInThisContainer": {
-    "message" : "Open New Tab in this Container"
+    "message": "Open New Tab in this Container"
   },
   "openTabs": {
     "message": "Open Tabs"
@@ -48,7 +48,7 @@
     "message": "A simple and secure way to manage your online life"
   },
   "onboarding-1-sec-description": {
-    "message" : "Use containers to organize tasks, manage accounts, and store sensitive data."
+    "message": "Use containers to organize tasks, manage accounts, and store sensitive data."
   },
   "onboarding-2-header": {
     "message": "Put containers to work for you."
@@ -203,6 +203,9 @@
   "keyboardShortCuts": {
     "message": "Keyboard Shortcuts:"
   },
+  "pageActionDescription": {
+    "message": "Show the \"Always open this in a container\" button in the URL bar"
+  },
   "onboarding": {
     "message": "Onboarding"
   },
@@ -243,7 +246,7 @@
     "message": "Container to open with Keyboard Shortcut $keyId$",
     "placeholders": {
       "keyId": {
-          "content": "$1"
+        "content": "$1"
       }
     }
   },

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -51,6 +51,11 @@ window.assignManager = {
       return !!syncEnabled;
     },
 
+    async getPageActionEnabled() {
+      const { pageActionEnabled } = await browser.storage.local.get({ pageActionEnabled: true });
+      return !!pageActionEnabled;
+    },
+
     async getReplaceTabEnabled() {
       const { replaceTabEnabled } = await browser.storage.local.get("replaceTabEnabled");
       return !!replaceTabEnabled;
@@ -429,6 +434,19 @@ window.assignManager = {
       browser.contextualIdentities.onRemoved
         .removeListener(this.contextualIdentityRemoved);
     }
+  },
+
+  async resetPageAction() {
+    const pageActionEnabled = await this.storageArea.getPageActionEnabled();
+    const tabs = await browser.tabs.query({});
+    const res = tabs.map((tab) => {
+      if (pageActionEnabled) {
+        return browser.pageAction.show(tab.id);
+      } else {
+        return browser.pageAction.hide(tab.id);
+      }
+    });
+    await Promise.all(res);
   },
 
   contextualIdentityCreated(changeInfo) {

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -23,6 +23,9 @@ const messageHandler = {
       case "resetBookmarksContext":
         response = assignManager.resetBookmarksMenuItem();
         break;
+      case "resetPageAction":
+        response = assignManager.resetPageAction();
+        break;
       case "deleteContainer":
         response = backgroundLogic.deleteContainer(m.message.userContextId);
         break;
@@ -179,6 +182,17 @@ const messageHandler = {
         throw e;
       });
     }, {urls: ["<all_urls>"], types: ["main_frame"]});
+
+    browser.tabs.onUpdated.addListener((tabId) => {
+      // check if the page action is enabled right away to avoid flashing
+      browser.storage.local.get({ pageActionEnabled: true }).then(({ pageActionEnabled }) => {
+        if (pageActionEnabled) {
+          browser.pageAction.show(tabId);
+        }
+      }).catch(e => {
+        throw e;
+      });
+    }, { properties: ["status"] });
 
     browser.tabs.onCreated.addListener((tab) => {
       // lets remember the last tab created so we can close it if it looks like a redirect

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -25,15 +25,23 @@ async function enableDisableReplaceTab() {
   await browser.storage.local.set({replaceTabEnabled: !!checkbox.checked});
 }
 
+async function enableDisablePageAction() {
+  const checkbox = document.querySelector("#pageActionCheck");
+  await browser.storage.local.set({pageActionEnabled: !!checkbox.checked});
+  await browser.runtime.sendMessage({ method: "resetPageAction" });
+}
+
 async function setupOptions() {
   const hasPermission = await browser.permissions.contains({permissions: ["bookmarks"]});
   const { syncEnabled } = await browser.storage.local.get("syncEnabled");
   const { replaceTabEnabled } = await browser.storage.local.get("replaceTabEnabled");
+  const { pageActionEnabled } = await browser.storage.local.get({ pageActionEnabled: true });
   if (hasPermission) {
     document.querySelector("#bookmarksPermissions").checked = true;
   }
   document.querySelector("#syncCheck").checked = !!syncEnabled;
   document.querySelector("#replaceTabCheck").checked = !!replaceTabEnabled;
+  document.querySelector("#pageActionCheck").checked = !!pageActionEnabled;
   setupContainerShortcutSelects();
 }
 
@@ -82,6 +90,7 @@ document.addEventListener("DOMContentLoaded", setupOptions);
 document.querySelector("#bookmarksPermissions").addEventListener( "change", requestPermissions);
 document.querySelector("#syncCheck").addEventListener( "change", enableDisableSync);
 document.querySelector("#replaceTabCheck").addEventListener( "change", enableDisableReplaceTab);
+document.querySelector("#pageActionCheck").addEventListener( "change", enableDisablePageAction);
 document.querySelector("button").addEventListener("click", resetOnboarding);
 
 for (let i=0; i < NUMBER_OF_KEYBOARD_SHORTCUTS; i++) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -121,8 +121,7 @@
     "default_icon": "img/container-openin-16.svg",
     "default_title": "Always open this in a Container",
     "default_popup": "pageActionPopup.html",
-    "pinned": false,
-    "show_matches": ["*://*/*"]
+    "pinned": false
   },
   "background": {
     "page": "js/background/index.html"

--- a/src/options.html
+++ b/src/options.html
@@ -28,6 +28,10 @@
         <span data-i18n-message-id="replaceTab"></span>
       </label>
       <p><em data-i18n-message-id="replaceTabDescription"></em></p>
+      <label>
+        <input type="checkbox" id="pageActionCheck">
+        <span data-i18n-message-id="pageActionDescription"></span>
+      </label>
       <h3 data-i18n-message-id="keyboardShortCuts"></h3>
       <p><em data-i18n-message-id="editWhichContainer"></em></p>
       <p><label>


### PR DESCRIPTION
In the recent Photon UI update, the ability to hide the page actions in the URL bar or manage them was removed. Personally, I never use the page action button to make a site always open in a tab, and always do it from the extensions toolbar button. Because this button just gets in my way, and because it used to be able to be moved until recently, I think making it toggleable would be a good idea.