### PR TITLE
Replace deprecated method `browser.extension.getURL()`

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -698,7 +698,7 @@ window.assignManager = {
 
   reloadPageInContainer(url, currentUserContextId, userContextId, index, active, neverAsk = false, openerTabId = null) {
     const cookieStoreId = backgroundLogic.cookieStoreId(userContextId);
-    const loadPage = browser.extension.getURL("confirm-page.html");
+    const loadPage = browser.runtime.getURL("confirm-page.html");
     // False represents assignment is not permitted
     // If the user has explicitly checked "Never Ask Again" on the warning page we will send them straight there
     if (neverAsk) {

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -22,7 +22,7 @@ const backgroundLogic = {
   },
 
   async getExtensionInfo() {
-    const manifestPath = browser.extension.getURL("manifest.json");
+    const manifestPath = browser.runtime.getURL("manifest.json");
     const response = await fetch(manifestPath);
     const extensionInfo = await response.json();
     return extensionInfo;

--- a/src/js/content-script.js
+++ b/src/js/content-script.js
@@ -24,7 +24,7 @@ async function addMessage(message) {
   divElement.innerText = message.text;
 
   const imageElement = document.createElement("img");
-  const imagePath = browser.extension.getURL("/img/container-site-d-24.png");
+  const imagePath = browser.runtime.getURL("/img/container-site-d-24.png");
   const response = await fetch(imagePath);
   const blob = await response.blob();
   const objectUrl = URL.createObjectURL(blob);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -41,7 +41,7 @@ function addRemoveSiteIsolation() {
 }
 
 async function getExtensionInfo() {
-  const manifestPath = browser.extension.getURL("manifest.json");
+  const manifestPath = browser.runtime.getURL("manifest.json");
   const response = await fetch(manifestPath);
   const extensionInfo = await response.json();
   return extensionInfo;


### PR DESCRIPTION
Replace calls to `browser.extension.getURL()` for `browser.runtime.getURL()`

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL

Close #2047