### PR TITLE
fix: Add unlimitedStorage permission to make sure storage.local does not hit quota limits or IndexedDB QuotaManager data eviction

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,6 +25,7 @@
     "idle",
     "management",
     "storage",
+    "unlimitedStorage",
     "tabs",
     "webRequestBlocking",
     "webRequest"


### PR DESCRIPTION
While looking into [Bug 1720487](https://bugzilla.mozilla.org/show_bug.cgi?id=1720487) I did notice that multi-account-container isn't currently requesting the ["unlimitedStorage" permission](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#unlimited_storage).

Without the "unlimitedStorage" permission, multi-account-container may more easily hit a quota limit.

Even besides the quota limit, at the moment the QuotaManager data eviction logic does not special case the extension origins and so there is a chance that below certain free disk space threshold the QuotaManager may select an extension origin while looking for the "least used origins to evict data from" (see [Bug 1720487 comment 1](https://bugzilla.mozilla.org/show_bug.cgi?id=1720487#c1) and [Bug 1720487 comment 6](https://bugzilla.mozilla.org/show_bug.cgi?id=1720487#c6).

(As a side note, the addition of the "unlimitedStorage" permission does not trigger a permission prompt, as expected for this kind of permission, and so it would not be prompting the user to accept the "unlimitedStorage" permission if included in a new version of the addon, in other words it does not introduce any friction for the existing users).