### PR TITLE
Manually add URLs to a container

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1928,8 +1928,8 @@ manage things like container crud */
 }
 
 #edit-container-site-link {
-  block-size: 36px;
   background: #ebebeb;
+  block-size: 36px;
 }
 
 #edit-container-site-link:hover {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1923,6 +1923,19 @@ manage things like container crud */
   margin-inline: 4px;
 }
 
+.edit-container-panel input[type="text"]#edit-container-panel-site-input {
+  inline-size: 80%;
+}
+
+#edit-container-site-link {
+  block-size: 36px;
+  background: #ebebeb;
+}
+
+#edit-container-site-link:hover {
+  background: #e3e3e3;
+}
+
 input[type="text"]:focus {
   /* Both a border and box-shadow of 1px are needed because using a 2px border
    * would redraw the input 1px farther to the left.

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1868,23 +1868,36 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
 
   async _addSite() {
     const formValues = new FormData(this._editForm);
-    console.log(formValues.get("container-id"));
-    console.log(formValues.get("site-name"));
     const url = formValues.get("site-name");
     const userContextId = formValues.get("container-id");
     const currentTab = await Logic.currentTab();
     const tabId = currentTab.id;
-    try {
-      await browser.runtime.sendMessage({
-        method: "setOrRemoveAssignment",
-        tabId: tabId,
-        url: url,
-        userContextId: userContextId,
-        value: false
-      });
-    } catch (e) {
-      console.log(e);
+    const fullURL = this.checkurl(url);
+    Logic.setOrRemoveAssignment(tabId, fullURL, userContextId, false);
+  },
+
+  checkurl(url){
+    // append "https://" if protocol not found
+    const regexWww = /.*www\..*/g;
+    const foundWww = url.match(regexWww);
+    const regexhttp = /^http:\/\/.*/g;
+    const regexhttps = /^https:\/\/.*/g;
+    const foundhttp = url.match(regexhttp);
+    const foundhttps = url.match(regexhttps);
+    let newURL = url;
+
+    if (!foundhttp && !foundhttps) {
+      newURL = "https://" + url;
     }
+
+    if (!foundWww) {
+      if (newURL.match(regexhttp)) {
+        newURL = "http://www." + newURL.substring(7);
+      } else if (newURL.match(regexhttps)) {
+        newURL = "https://www." + newURL.substring(8);
+      }
+    }
+    return newURL;
   },
 
   showAssignedContainers(assignments) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1875,7 +1875,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     const tabId = currentTab.id;
     const fullURL = this.checkUrl(url);
 
-    if (fullURL !== "") {
+    if (fullURL !== null) {
       // Assign URL to container
       await Logic.setOrRemoveAssignment(tabId, fullURL, userContextId, false);
 
@@ -1897,7 +1897,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     let newURL = url;
 
     if (!url.match(validUrl)) {
-      return "";
+      return null;
     }
 
     if (!url.match(regexhttp) && !url.match(regexhttps)) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1875,32 +1875,36 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     const tabId = currentTab.id;
     const fullURL = this.checkUrl(url);
 
-    // Assign URL to container
-    await Logic.setOrRemoveAssignment(tabId, fullURL, userContextId, false);
+    if (fullURL !== "") {
+      // Assign URL to container
+      await Logic.setOrRemoveAssignment(tabId, fullURL, userContextId, false);
 
-    // Clear form
-    document.querySelector("#edit-container-panel-site-input").value = "";
+      // Clear form
+      document.querySelector("#edit-container-panel-site-input").value = "";
 
-    // Show new assignments
-    const assignments = await Logic.getAssignmentObjectByContainer(userContextId);
-    this.showAssignedContainers(assignments);
+      // Show new assignments
+      const assignments = await Logic.getAssignmentObjectByContainer(userContextId);
+      this.showAssignedContainers(assignments);
+    }
   },
 
   checkUrl(url){
     // append "https://" if protocol not found
+    const validUrl = /[\w.-]+(?:\.[\w.-]+)/g;
     const regexWww = /.*www\..*/g;
-    const foundWww = url.match(regexWww);
     const regexhttp = /^http:\/\/.*/g;
     const regexhttps = /^https:\/\/.*/g;
-    const foundhttp = url.match(regexhttp);
-    const foundhttps = url.match(regexhttps);
     let newURL = url;
 
-    if (!foundhttp && !foundhttps) {
+    if (!url.match(validUrl)) {
+      return "";
+    }
+
+    if (!url.match(regexhttp) && !url.match(regexhttps)) {
       newURL = "https://" + url;
     }
 
-    if (!foundWww) {
+    if (!url.match(regexWww)) {
       if (newURL.match(regexhttp)) {
         newURL = "http://www." + newURL.substring(7);
       } else if (newURL.match(regexhttps)) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1872,7 +1872,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     const userContextId = formValues.get("container-id");
     const currentTab = await Logic.currentTab();
     const tabId = currentTab.id;
-    const fullURL = this.checkurl(url);
+    const fullURL = this.checkUrl(url);
     Logic.setOrRemoveAssignment(tabId, fullURL, userContextId, false);
   },
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1876,7 +1876,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     Logic.setOrRemoveAssignment(tabId, fullURL, userContextId, false);
   },
 
-  checkurl(url){
+  checkUrl(url){
     // append "https://" if protocol not found
     const regexWww = /.*www\..*/g;
     const foundWww = url.match(regexWww);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1821,7 +1821,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
 
     // Add new site to current container
     const siteLink = document.querySelector("#edit-container-site-link");
-    Logic.addEnterHandler(siteLink, () => {
+    Utils.addEnterHandler(siteLink, () => {
       this._addSite();
     });
   },
@@ -1958,7 +1958,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
         trElement.getElementsByClassName("favicon")[0].appendChild(Utils.createFavIconElement(assumedUrl));
         const deleteButton = trElement.querySelector(".delete-assignment");
         const that = this;
-        Logic.addEnterHandler(deleteButton, async () => {
+        Utils.addEnterHandler(deleteButton, async () => {
           const userContextId = Logic.currentUserContextId();
           // Lets show the message to the current tab
           // TODO remove then when firefox supports arrow fn async

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1877,7 +1877,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
 
     if (baseURL !== null) {
       // Assign URL to container
-      await Logic.setOrRemoveAssignment(tabId, baseURL, userContextId, false);
+      await Utils.setOrRemoveAssignment(tabId, baseURL, userContextId, false);
 
       // Clear form
       document.querySelector("#edit-container-panel-site-input").value = "";
@@ -1963,7 +1963,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
           // Lets show the message to the current tab
           // TODO remove then when firefox supports arrow fn async
           const currentTab = await Logic.currentTab();
-          Logic.setOrRemoveAssignment(currentTab.id, assumedUrl, userContextId, true);
+          Utils.setOrRemoveAssignment(currentTab.id, assumedUrl, userContextId, true);
           delete assignments[siteKey];
           that.showAssignedContainers(assignments);
         });

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1870,6 +1870,21 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     const formValues = new FormData(this._editForm);
     console.log(formValues.get("container-id"));
     console.log(formValues.get("site-name"));
+    const url = formValues.get("site-name");
+    const userContextId = formValues.get("container-id");
+    const currentTab = await Logic.currentTab();
+    const tabId = currentTab.id;
+    try {
+      await browser.runtime.sendMessage({
+        method: "setOrRemoveAssignment",
+        tabId: tabId,
+        url: url,
+        userContextId: userContextId,
+        value: false
+      });
+    } catch (e) {
+      console.log(e);
+    }
   },
 
   showAssignedContainers(assignments) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1889,27 +1889,22 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
   },
 
   checkUrl(url){
-    // append "https://" if protocol not found
     const validUrl = /[\w.-]+(?:\.[\w.-]+)/g;
-    const regexWww = /.*www\..*/g;
-    const regexhttp = /^http:\/\/.*/g;
-    const regexhttps = /^https:\/\/.*/g;
+    const regexProtocol = /^https?:\/\/.*/g;
+    const valid = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www\.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w\-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[.!/\\\w]*))?)/g;
     let newURL = url;
 
     if (!url.match(validUrl)) {
       return null;
     }
 
-    if (!url.match(regexhttp) && !url.match(regexhttps)) {
+    // append "https://" if protocol not found
+    if (!url.match(regexProtocol)) {
       newURL = "https://" + url;
     }
 
-    if (!url.match(regexWww)) {
-      if (newURL.match(regexhttp)) {
-        newURL = "http://www." + newURL.substring(7);
-      } else if (newURL.match(regexhttps)) {
-        newURL = "https://www." + newURL.substring(8);
-      }
+    if (!newURL.match(valid)) {
+      return null;
     }
     return newURL;
   },

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1927,7 +1927,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
         /* As we don't have the full or correct path the best we can assume is the path is HTTPS and then replace with a broken icon later if it doesn't load.
            This is pending a better solution for favicons from web extensions */
         const assumedUrl = `https://${site.hostname}/favicon.ico`;
-        trElement.innerHTML = escaped`
+        trElement.innerHTML = Utils.escaped`
         <div class="favicon"></div>
         <div title="${site.hostname}" class="truncate-text hostname">
           ${site.hostname}

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1867,13 +1867,23 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
   },
 
   async _addSite() {
+    // Get URL and container ID from form
     const formValues = new FormData(this._editForm);
     const url = formValues.get("site-name");
     const userContextId = formValues.get("container-id");
     const currentTab = await Logic.currentTab();
     const tabId = currentTab.id;
     const fullURL = this.checkUrl(url);
-    Logic.setOrRemoveAssignment(tabId, fullURL, userContextId, false);
+
+    // Assign URL to container
+    await Logic.setOrRemoveAssignment(tabId, fullURL, userContextId, false);
+
+    // Clear form
+    document.querySelector("#edit-container-panel-site-input").value = "";
+
+    // Show new assignments
+    const assignments = await Logic.getAssignmentObjectByContainer(userContextId);
+    this.showAssignedContainers(assignments);
   },
 
   checkUrl(url){
@@ -1997,7 +2007,8 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     });
     // Only show ability to add site if it's an existing container
     document.querySelector("#edit-container-panel-add-site").hidden = !userContextId;
-
+    // Make site input empty
+    document.querySelector("#edit-container-panel-site-input").value = "";
     document.querySelector("#edit-container-panel-name-input").value = identity.name || "";
     document.querySelector("#edit-container-panel-usercontext-input").value = userContextId || NEW_CONTAINER_ID;
     const containerName = document.querySelector("#edit-container-panel-name-input");

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -59,29 +59,29 @@ const Utils = {
   },
 
   /**
- * Escapes any occurances of &, ", <, > or / with XML entities.
- *
- * @param {string} str
- *        The string to escape.
- * @return {string} The escaped string.
- */
+   * Escapes any occurances of &, ", <, > or / with XML entities.
+   *
+   * @param {string} str
+   *        The string to escape.
+   * @return {string} The escaped string.
+   */
   escapeXML(str) {
     const replacements = { "&": "&amp;", "\"": "&quot;", "'": "&apos;", "<": "&lt;", ">": "&gt;", "/": "&#x2F;" };
     return String(str).replace(/[&"'<>/]/g, m => replacements[m]);
   },
 
   /**
- * A tagged template function which escapes any XML metacharacters in
- * interpolated values.
- *
- * @param {Array<string>} strings
- *        An array of literal strings extracted from the templates.
- * @param {Array} values
- *        An array of interpolated values extracted from the template.
- * @returns {string}
- *        The result of the escaped values interpolated with the literal
- *        strings.
- */
+   * A tagged template function which escapes any XML metacharacters in
+   * interpolated values.
+   *
+   * @param {Array<string>} strings
+   *        An array of literal strings extracted from the templates.
+   * @param {Array} values
+   *        An array of interpolated values extracted from the template.
+   * @returns {string}
+   *        The result of the escaped values interpolated with the literal
+   *        strings.
+   */
   escaped(strings, ...values) {
     const result = [];
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -131,7 +131,9 @@
     "default_title": "__MSG_alwaysOpenSiteInContainer__",
     "default_popup": "pageActionPopup.html",
     "pinned": false,
-    "show_matches": ["*://*/*"]
+    "show_matches": [
+      "*://*/*"
+    ]
   },
   "background": {
     "page": "js/background/index.html"

--- a/src/popup.html
+++ b/src/popup.html
@@ -315,8 +315,8 @@
           <input type="text" class="proxies" name="country-code" id="country-code-input" maxlength="5" hidden/>
           <input type="text" class="proxies" name="city-name" id="city-name-input" maxlength="5" hidden/>
         </fieldset>
-        <fieldset id="edit-container-panel-add-site">
-          <legend class="form-header">Add site</legend>
+        <fieldset id="edit-container-panel-add-site" hidden>
+          <legend class="form-header">Assign site</legend>
           <input type="text" name="site-name" id="edit-container-panel-site-input"/>
           <a class="button secondary" id="edit-container-site-link">Add</a>
         </fieldset>

--- a/src/popup.html
+++ b/src/popup.html
@@ -309,7 +309,7 @@
         <fieldset id="edit-container-panel-choose-icon" class="radio-choice">
           <legend class="form-header" data-i18n-message-id="icon"></legend>
         </fieldset>
-        <fieldset class="proxies"> <!---- PROXIES -->
+        <fieldset class="proxies"> <!-- PROXIES -->
           <input type="text" class="proxies" name="container-proxy" id="edit-container-panel-proxy" placeholder="type://host:port" hidden/>
           <input type="text" class="proxies" name="moz-proxy-enabled" id="moz-proxy-enabled" maxlength="5" hidden/>
           <input type="text" class="proxies" name="country-code" id="country-code-input" maxlength="5" hidden/>

--- a/src/popup.html
+++ b/src/popup.html
@@ -315,6 +315,11 @@
           <input type="text" class="proxies" name="country-code" id="country-code-input" maxlength="5" hidden/>
           <input type="text" class="proxies" name="city-name" id="city-name-input" maxlength="5" hidden/>
         </fieldset>
+        <fieldset id="edit-container-panel-add-site">
+          <legend class="form-header">Add site</legend>
+          <input type="text" name="site-name" id="edit-container-panel-site-input"/>
+          <a class="button secondary" id="edit-container-site-link">Add</a>
+        </fieldset>
       </form>
       <div id="edit-container-options">
         <div class="options-header" data-i18n-message-id="options"></div>

--- a/test/issues/1670.test.js
+++ b/test/issues/1670.test.js
@@ -1,79 +1,137 @@
 const {initializeWithTab} = require("../common");
 
+console.log("TRACE START");
 describe("#1670", function () {
+  console.log("TRACE 0");
   beforeEach(async function () {
+    console.log("TRACE 1.0");
     this.webExt = await initializeWithTab();
+    console.log("TRACE 1.1");
   });
+  console.log("TRACE 2");
 
   afterEach(function () {
+    console.log("TRACE 3.0");
     this.webExt.destroy();
+    console.log("TRACE 3.1");
   });
+  console.log("TRACE 4");
 
   describe("creating a new container", function () {
+    console.log("TRACE 5.0");
     beforeEach(async function () {
+      console.log("TRACE 5.1.0");
       await this.webExt.popup.helper.clickElementById("manage-containers-link");
+      console.log("TRACE 5.1.1");
       await this.webExt.popup.helper.clickElementById("new-container");
+      console.log("TRACE 5.1.2");
       await this.webExt.popup.helper.clickElementById("create-container-ok-link");
+      console.log("TRACE 5.1.3");
     });
+    console.log("TRACE 5.2");
 
     it("should create it in the browser as well", function () {
+      console.log("TRACE 5.3.0");
       this.webExt.background.browser.contextualIdentities.create.should.have.been.calledOnce;
     });
+    console.log("TRACE 5.4");
 
     describe("manually assign a valid URL to a container", function () {
+      console.log("TRACE 5.5.0");
       const exampleUrl = "https://github.com/mozilla/multi-account-containers";
       beforeEach(async function () {
+        console.log("TRACE 5.5.1.0");
         await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        console.log("TRACE 5.5.1.1");
         await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        console.log("TRACE 5.5.1.2");
         this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        console.log("TRACE 5.5.1.3");
         await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+        console.log("TRACE 5.5.1.4");
       });
+      console.log("TRACE 5.5.2");
 
       it("should assign the URL to a container", function () {
+        console.log("TRACE 5.5.3.0");
         this.webExt.background.browser.contextualIdentities.create.should.have.been.calledOnce;
       });
+      console.log("TRACE 5.5.4");
     });
+    console.log("TRACE 5.6");
 
     describe("manually assign valid URL without protocol to a container", function () {
+      console.log("TRACE 5.7.0");
       const exampleUrl = "github.com/mozilla/multi-account-containers";
       beforeEach(async function () {
+        console.log("TRACE 5.7.1.0");
         await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        console.log("TRACE 5.7.1.1");
         await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        console.log("TRACE 5.7.1.2");
         this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        console.log("TRACE 5.7.1.3");
         await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+        console.log("TRACE 5.7.1.4");
       });
+      console.log("TRACE 5.7.2");
 
       it("should assign the URL without protocol to a container", function () {
+        console.log("TRACE 5.7.3.0");
         this.webExt.background.browser.contextualIdentities.create.should.have.been.calledOnce;
       });
+      console.log("TRACE 5.7.4");
     });
+    console.log("TRACE 5.8");
 
     describe("manually assign an invalid URL to a container", function () {
+      console.log("TRACE 5.9.0");
       const exampleUrl = "github";
       beforeEach(async function () {
+        console.log("TRACE 5.9.1.0");
         await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        console.log("TRACE 5.9.1.1");
         await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        console.log("TRACE 5.9.1.2");
         this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        console.log("TRACE 5.9.1.3");
         await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+        console.log("TRACE 5.9.1.4");
       });
+      console.log("TRACE 5.9.2");
 
       it("should not assign the URL to a container", function () {
+        console.log("TRACE 5.9.3.0");
         this.webExt.background.browser.contextualIdentities.update.should.not.have.been.called;
       });
+      console.log("TRACE 5.9.4");
     });
+    console.log("TRACE 5.10");
 
     describe("manually assign empty URL to a container", function () {
+      console.log("TRACE 5.11.0");
       const exampleUrl = "";
       beforeEach(async function () {
+        console.log("TRACE 5.11.1.0");
         await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        console.log("TRACE 5.11.1.1");
         await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        console.log("TRACE 5.11.1.2");
         this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        console.log("TRACE 5.11.1.3");
         await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+        console.log("TRACE 5.11.1.4");
       });
+      console.log("TRACE 5.11.2");
 
       it("should not assign the URL to a container", function () {
+        console.log("TRACE 5.11.3.0");
         this.webExt.background.browser.contextualIdentities.update.should.not.have.been.called;
       });
+      console.log("TRACE 5.11.4");
     });
+    console.log("TRACE 5.12");
   });
+  console.log("TRACE 6");
 });
+console.log("TRACE END");

--- a/test/issues/1670.test.js
+++ b/test/issues/1670.test.js
@@ -11,8 +11,9 @@ describe("#1670", function () {
 
   describe("creating a new container", function () {
     beforeEach(async function () {
-      await this.webExt.popup.helper.clickElementById("container-add-link");
-      await this.webExt.popup.helper.clickElementById("edit-container-ok-link");
+      await this.webExt.popup.helper.clickElementById("manage-containers-link");
+      await this.webExt.popup.helper.clickElementById("new-container");
+      await this.webExt.popup.helper.clickElementById("create-container-ok-link");
     });
 
     it("should create it in the browser as well", function () {

--- a/test/issues/1670.test.js
+++ b/test/issues/1670.test.js
@@ -41,7 +41,7 @@ describe("#1670", function () {
       const exampleUrl = "https://github.com/mozilla/multi-account-containers";
       beforeEach(async function () {
         console.log("TRACE 5.5.1.0");
-        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementById("manage-containers-link");
         console.log("TRACE 5.5.1.1");
         await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
         console.log("TRACE 5.5.1.2");
@@ -65,7 +65,7 @@ describe("#1670", function () {
       const exampleUrl = "github.com/mozilla/multi-account-containers";
       beforeEach(async function () {
         console.log("TRACE 5.7.1.0");
-        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementById("manage-containers-link");
         console.log("TRACE 5.7.1.1");
         await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
         console.log("TRACE 5.7.1.2");
@@ -89,7 +89,7 @@ describe("#1670", function () {
       const exampleUrl = "github";
       beforeEach(async function () {
         console.log("TRACE 5.9.1.0");
-        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementById("manage-containers-link");
         console.log("TRACE 5.9.1.1");
         await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
         console.log("TRACE 5.9.1.2");
@@ -113,7 +113,7 @@ describe("#1670", function () {
       const exampleUrl = "";
       beforeEach(async function () {
         console.log("TRACE 5.11.1.0");
-        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementById("manage-containers-link");
         console.log("TRACE 5.11.1.1");
         await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
         console.log("TRACE 5.11.1.2");

--- a/test/issues/1670.test.js
+++ b/test/issues/1670.test.js
@@ -1,0 +1,81 @@
+// const expect = require("chai").expect;
+const {initializeWithTab} = require("../common");
+
+describe("#1670", function () {
+  beforeEach(async function () {
+    this.webExt = await initializeWithTab();
+  });
+
+  afterEach(function () {
+    this.webExt.destroy();
+  });
+
+  describe("creating a new container", function () {
+    beforeEach(async function () {
+      await this.webExt.popup.helper.clickElementById("container-add-link");
+      await this.webExt.popup.helper.clickElementById("edit-container-ok-link");
+    });
+
+    it("should create it in the browser as well", function () {
+      this.webExt.background.browser.contextualIdentities.create.should.have.been.calledOnce;
+    });
+
+    describe("manually assign a valid URL to a container", function () {
+      const exampleUrl = "https://github.com/mozilla/multi-account-containers";
+      beforeEach(async function () {
+        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+      });
+
+      it("should assign the URL to a container", function () {
+        this.webExt.background.browser.contextualIdentities.create.should.have.been.calledOnce;
+      });
+    });
+
+    describe("manually assign valid URL without protocol to a container", function () {
+      const exampleUrl = "github.com/mozilla/multi-account-containers";
+      beforeEach(async function () {
+        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+      });
+
+      it("should assign the URL without protocol to a container", function () {
+        this.webExt.background.browser.contextualIdentities.create.should.have.been.calledOnce;
+      });
+    });
+
+    describe("manually assign an invalid URL to a container", function () {
+      const exampleUrl = "github";
+      beforeEach(async function () {
+        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+      });
+
+      it("should not assign the URL to a container", function () {
+        // console.log(this.webExt.background.browser.contextualIdentities);
+        // expect( console.log.calledOnce ).to.be.true;
+        this.webExt.background.browser.contextualIdentities.update.should.not.have.been.called;
+      });
+    });
+
+    describe("manually assign empty URL to a container", function () {
+      const exampleUrl = "";
+      beforeEach(async function () {
+        await this.webExt.popup.helper.clickElementById("edit-containers-link");
+        await this.webExt.popup.helper.clickElementByQuerySelectorAll(".edit-container-icon", "last");
+        this.webExt.popup.window.document.getElementById("edit-container-panel-site-input").value = exampleUrl;
+        await this.webExt.popup.helper.clickElementById("edit-container-site-link");
+      });
+
+      it("should not assign the URL to a container", function () {
+        this.webExt.background.browser.contextualIdentities.update.should.not.have.been.called;
+      });
+    });
+  });
+});

--- a/test/issues/1670.test.js
+++ b/test/issues/1670.test.js
@@ -1,4 +1,3 @@
-// const expect = require("chai").expect;
 const {initializeWithTab} = require("../common");
 
 describe("#1670", function () {
@@ -58,8 +57,6 @@ describe("#1670", function () {
       });
 
       it("should not assign the URL to a container", function () {
-        // console.log(this.webExt.background.browser.contextualIdentities);
-        // expect( console.log.calledOnce ).to.be.true;
         this.webExt.background.browser.contextualIdentities.update.should.not.have.been.called;
       });
     });


### PR DESCRIPTION
This PR is a repeat of PR #1688 by @sherry13131, but rebased on top of today's master.

In addition I have:
* included some small tweaks to the style tags to bring it into line with other changes made to the same block.
* cleaned up trailing whitespace on introduced code.
* fixed a latent bug in the verification code when adding a new URL.

The original code allowed any text containing any URL to be added, which I'm pretty sure would result in entries that would never be matched, so I added my own commit that trims any provided URL so that they are just <tt>http(s)://<i>dom.ain</i></tt> (with any username, password, port, path, query string and/or anchor removed).

Because I've rebased the code, a number of merge commits in the original PR have vanished, but they were purely between internal development branches in the same repo, not part of the main PR.
