### PR TITLE
Move proxy as optional permission/availabe in the options page

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -221,6 +221,12 @@
   "enableBookMarkMenus": {
     "message": "Enable Bookmark Menus"
   },
+  "enableProxy": {
+    "message": "Enable custom per-container proxy settings"
+  },
+  "enableProxyDescription": {
+    "message": "This setting allows you to route all traffic from a specific Container through a proxy. This feature requires the proxy permission. This permission grants the add-on to control browser proxy settings."
+  },
   "enableSync": {
     "message": "Enable Sync"
   },

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -585,6 +585,10 @@ manage things like container crud */
   padding-inline-start: 0;
 }
 
+.edit-container-panel fieldset.proxy-container-settings.is-hidden {
+  display: none;
+}
+
 .edit-container-panel fieldset:last-of-type {
   margin-block-start: 16px;
 }

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -384,8 +384,6 @@ window.assignManager = {
       permissions: ["proxy"]
     });
 
-    console.log("hasProxyPermission: ", hasProxyPermission);
-    
     if (hasProxyPermission) {
       browser.proxy.onRequest.addListener(this.handleProxifiedRequest, {urls: ["<all_urls>"]});
     }

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -372,7 +372,7 @@ window.assignManager = {
     return currentContainerState && currentContainerState.isIsolated;
   },
 
-  init() {
+  async init() {
     browser.contextMenus.onClicked.addListener((info, tab) => {
       info.bookmarkId ?
         this._onClickedBookmark(info) :
@@ -380,7 +380,15 @@ window.assignManager = {
     });
 
     // Before anything happens we decide if the request should be proxified
-    browser.proxy.onRequest.addListener(this.handleProxifiedRequest, {urls: ["<all_urls>"]});
+    const hasProxyPermission = await browser.permissions.contains({
+      permissions: ["proxy"]
+    });
+
+    console.log("hasProxyPermission: ", hasProxyPermission);
+    
+    if (hasProxyPermission) {
+      browser.proxy.onRequest.addListener(this.handleProxifiedRequest, {urls: ["<all_urls>"]});
+    }
 
     // Before a request is handled by the browser we decide if we should
     // route through a different container

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -23,6 +23,9 @@ const messageHandler = {
       case "resetBookmarksContext":
         response = assignManager.resetBookmarksMenuItem();
         break;
+      case "resetProxySupport":
+        response = assignManager.init();
+        break;
       case "deleteContainer":
         response = backgroundLogic.deleteContainer(m.message.userContextId);
         break;

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -106,6 +106,10 @@ const messageHandler = {
           return assignManager._setOrRemoveAssignment(tab.id, m.url, m.newUserContextId, m.value);
         });
         break;
+      case "proxyPermissionCheck":
+        return await browser.permissions.contains({
+          permissions: ["proxy"],
+        });
       }
       return response;
     });

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -18,6 +18,10 @@ async function requestPermissions(event) {
   if (permission === "bookmarks") {
     browser.runtime.sendMessage({ method: "resetBookmarksContext" });
   }
+  
+  if (permission === "proxy") {
+    browser.runtime.sendMessage({ method: "resetProxySupport" });
+  }
 
 }
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1428,6 +1428,16 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       iconInput.checked = iconInput.value === identity.icon;
     });
 
+    const hasProxyPermission = await browser.runtime.sendMessage({
+      method: "proxyPermissionCheck",
+    });
+
+    console.log("hasProxyPermission: ", hasProxyPermission);
+
+    if (hasProxyPermission) {
+      document.querySelector(".proxy-container-settings").classList.remove("is-hidden");
+    }
+
     // Clear the proxy field before doing the retrieval requests below
     document.querySelector("#edit-container-panel-proxy").value = "";
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1428,11 +1428,11 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       iconInput.checked = iconInput.value === identity.icon;
     });
 
+    // Query if user has proxy permissions. 
+    // If so, we want to show the custom proxy settings options for the container: 
     const hasProxyPermission = await browser.runtime.sendMessage({
       method: "proxyPermissionCheck",
     });
-
-    console.log("hasProxyPermission: ", hasProxyPermission);
 
     if (hasProxyPermission) {
       document.querySelector(".proxy-container-settings").classList.remove("is-hidden");

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,11 +28,11 @@
     "unlimitedStorage",
     "tabs",
     "webRequestBlocking",
-    "webRequest",
-    "proxy"
+    "webRequest"
   ],
   "optional_permissions": [
-    "bookmarks"
+    "bookmarks",
+    "proxy"
   ],
   "commands": {
     "_execute_browser_action": {

--- a/src/options.html
+++ b/src/options.html
@@ -11,11 +11,15 @@
     <form>
       <h3 data-i18n-message-id="optionalPermissions"></h3>
       <label >
-        <input type="checkbox" id="bookmarksPermissions">
+        <input class="permissionCheckbox" data-permission="bookmarks" type="checkbox" id="bookmarksPermission">
         <span data-i18n-message-id="enableBookMarkMenus"></span>
-
       </label>
       <p><em data-i18n-message-id="enableBookMarkMenusDescription"></em></p>
+      <label > 
+        <input class="permissionCheckbox" data-permission="proxy" type="checkbox" id="proxyPermission">
+        <span data-i18n-message-id="enableProxy"></span>
+      </label>
+      <p><em data-i18n-message-id="enableProxyDescription"></em></p>
       <h3 data-i18n-message-id="firefoxAccountsSync"></h3>
       <label>
         <input type="checkbox" id="syncCheck">

--- a/src/popup.html
+++ b/src/popup.html
@@ -277,7 +277,7 @@
         <fieldset id="edit-container-panel-choose-icon" class="radio-choice">
           <legend class="form-header" data-i18n-message-id="icon"></legend>
         </fieldset>
-        <fieldset>
+        <fieldset class="proxy-container-settings is-hidden">
           <legend>Proxy (Optional)</legend>
           <input type="text" name="container-proxy" id="edit-container-panel-proxy" maxlength="50" placeholder="type://host:port"/>
         </fieldset>


### PR DESCRIPTION
This PR does the following: 
- Moves proxy to optional permission in the manifest
- Adds a checkbox in the options page to toggle this permission/feature
- Show/hide the proxy settings in the container mgmt panel based on the permission status 

