### PR TITLE
Vertically center icons when container name is " ".

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1764,7 +1764,7 @@ h3.title {
 .menu-item td {
   align-items: center;
   display: flex;
-  width: 100%;
+  inline-size: 100%;
 }
 
 .menu-item.drag-over td {


### PR DESCRIPTION
Fixes MAC-661

**Before:**
<img width="200" alt="Screen Shot 2021-10-26 at 9 23 50 PM" src="https://user-images.githubusercontent.com/22355127/138989933-dc436420-a44e-493f-a3c0-3b223248168d.png">


**After:**
<img width="200" alt="Screen Shot 2021-10-26 at 9 29 28 PM" src="https://user-images.githubusercontent.com/22355127/138989950-f3e9df55-b563-485c-92ab-eb408bd79b5d.png">
