### PR TITLE
Run builds also as scheduled task

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - production
+  schedule:
+    - cron: '0 2 * * *' # Daily at 2AM UTC      
 
 jobs:
   builds:


### PR DESCRIPTION
I don't expect code changes to be very frequent, once code stabilizes. We still need to ensure localizers can test their work without waiting for days.