### PR TITLE
Add tooltip string

### DIFF
--- a/src/js/mozillaVpn.js
+++ b/src/js/mozillaVpn.js
@@ -10,6 +10,7 @@ const MozillaVPN = {
       return;
     }
 
+    const tooltipProxyWarning = browser.i18n.getMessage("tooltipWarning");
     for (const el of document.querySelectorAll("[data-cookie-store-id]")) {
       const cookieStoreId = el.dataset.cookieStoreId;
 
@@ -28,6 +29,10 @@ const MozillaVPN = {
         }
         if (!mozillaVpnConnected && proxy.mozProxyEnabled) {
           flag.classList.add("proxy-unavailable");
+          const tooltip = el.querySelector(".tooltip.proxy-unavailable");
+          if (tooltip) {
+            tooltip.textContent = tooltipProxyWarning;
+          }
           const menuItemName = el.querySelector(".menu-item-name");
           if (menuItemName) {
             el.querySelector(".menu-item-name").dataset.mozProxyWarning = "proxy-unavailable";

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -749,7 +749,7 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
             </div>
           </div>
           <span class="menu-text">${identity.name}</span>
-          <span class="tooltip proxy-unavailable">This container has been configured to use a Mozilla VPN proxy, but Mozilla VPN is not on. Turn Mozilla VPN on to use this proxy.</span>
+          <span class="tooltip proxy-unavailable"></span>
         </div>
         <span class="menu-right-float">
           <img alt="" class="always-open-in-flag flag-img" src="/img/flags/.png"/>
@@ -767,8 +767,6 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       tr.appendChild(td);
 
       const openInThisContainer = tr.querySelector(".menu-item-name");
-      // const mozProxyWarning = await MozillaVPN.getProxyWarnings(proxies[identity.cookieStoreId]);
-      // openInThisContainer.dataset.mozProxyWarning = mozProxyWarning;
       Utils.addEnterHandler(openInThisContainer, (e) => {
         e.preventDefault();
         if (openInThisContainer.dataset.mozProxyWarning === "proxy-unavailable") {


### PR DESCRIPTION
This implements the last integration-specific string and can be merged ~~after https://github.com/mozilla-l10n/multi-account-containers-l10n/pull/8 has been merged and the 'tooltipWarning' string ID is available~~ now that https://github.com/mozilla-l10n/multi-account-containers-l10n/pull/8 has been merged and the 'tooltipWarning' string ID is available.