### PR TITLE
Remove nonexistent "applications" manifest key

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,12 +8,6 @@
     "48": "img/container-site-d-48.png",
     "96": "img/container-site-d-96.png"
   },
-  "applications": {
-    "gecko": {
-      "id": "@testpilot-containers",
-      "strict_min_version": "91.1.0"
-    }
-  },
   "homepage_url": "https://github.com/mozilla/multi-account-containers#readme",
   "permissions": [
     "<all_urls>",
@@ -37,7 +31,8 @@
   ],
   "browser_specific_settings": {
     "gecko": {
-      "id": "@testpilot-containers"
+      "id": "@testpilot-containers",
+      "strict_min_version": "91.1.0"
     }
   },
   "commands": {


### PR DESCRIPTION
- Removes the `"applications"` key from manifest.json, which doesn't seem to be a valid key (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json).
- Moves `strict_min_version` to `browser_specific_settings > gecko > strict_min_version` where the AMO linters can find it. 