### PR TITLE
Add "toolbar" to icon color list

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -61,7 +61,7 @@
   --icon-button-size: calc(calc(var(--block-line-separation-size) * 2) + 1.66rem); /* 20px */
   --inactive-opacity: 0.3;
   --overflow-size: 1px;
-  --icon-fit: 8;
+  --icon-fit: 9;
 
   background: var(--bgColor);
   margin-block: 0;

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -359,6 +359,11 @@ table {
   --identity-icon-color: #af51f5;
 }
 
+[data-identity-color="toolbar"] {
+  --identity-tab-color: var(--text-color-primary);
+  --identity-icon-color: var(--text-color-primary);
+}
+
 [data-identity-icon="fingerprint"] {
   --identity-icon: url("/img/usercontext.svg#fingerprint");
 }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1813,7 +1813,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
       return Utils.escaped`<input type="radio" value="${containerColor}" name="container-color" id="edit-container-panel-choose-color-${containerColor}" />
      <label for="edit-container-panel-choose-color-${containerColor}" class="usercontext-icon choose-color-icon" data-identity-icon="circle" data-identity-color="${containerColor}">`;
     };
-    const colors = ["blue", "turquoise", "green", "yellow", "orange", "red", "pink", "purple"];
+    const colors = ["blue", "turquoise", "green", "yellow", "orange", "red", "pink", "purple", "toolbar"];
     const colorRadioFieldset = document.getElementById("edit-container-panel-choose-color");
     colors.forEach((containerColor) => {
       const templateInstance = document.createElement("div");


### PR DESCRIPTION
[Facebook Container](https://addons.mozilla.org/en-US/firefox/addon/facebook-container/) uses the icon color "toolbar", which is not included in `src/popup.js`.

In the "Manage Containers" panel, if I click on "Facebook" and then go back, the icon color for Facebook turns blue with no obvious way to reset it. The only way to change the color back is under the Container Tabs setting in about:preferences.

Since "toolbar" is a user-selectable color in about:preferences, I think it makes sense to include it as an option in the MAC popup as well.