### PR TITLE
Automatically focus confirm button on confirm page

### DIFF
--- a/src/confirm-page.html
+++ b/src/confirm-page.html
@@ -24,7 +24,7 @@
       <br />
       <div class="button-container">
         <button id="deny" class="button" data-message-id="openInContainer" data-message-arg="current-container-name"></button>
-        <button id="confirm" class="button primary" data-message-id="openInContainer" data-message-arg="container-name"></button>
+        <button id="confirm" class="button primary" autofocus data-message-id="openInContainer" data-message-arg="container-name"></button>
       </div>
     </form>
   </main>


### PR DESCRIPTION
Fixes #2214

This is a regression introduced in commit:
05dc48eac2d12dc65dc2e062ad3d64d0fe77051a

The autofocus attribute was removed unexpectedly in a localization
change.