### PR TITLE
fix #2248: proxy DNS too

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -198,11 +198,11 @@ window.assignManager = {
     }
 
     if (!result.proxy.mozProxyEnabled) {
-      return result.proxy;
+      return [{ ...result.proxy, proxyDNS: true }];
     }
 
     // Let's add the isolation key.
-    return [{ ...result.proxy, connectionIsolationKey: "" + MozillaVPN_Background.isolationKey }];
+    return [{ ...result.proxy, connectionIsolationKey: "" + MozillaVPN_Background.isolationKey, proxyDNS: true }];
   },
 
   // Before a request is handled by the browser we decide if we should


### PR DESCRIPTION
Happy New Year!

### Testing instructions:
1. Run `web-ext run -s src` on the `main` branch of this repo
1. Assign a proxy to a container
2. Open a tab in that container
3. Visit https://www.dnsleaktest.com
   * [ ] Should see the IP & location of the proxy server
4. Click "Standard Test"
   * [ ] You will **NOT** see the IP & location of the proxy server! 🙀
6. Run `web-ext run -s src` on this `proxy-dns-2248` branch of code
7. Assign a proxy to a container
8. Open a tab in that container to https://www.dnsleaktest.com
   * [ ] Should see the IP & location of the proxy server
9. Click "Standard Test"
   * [ ] You will **STILL** see the IP & location of the proxy server! 👍