### PR TITLE
Remove delete container warning

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1542,6 +1542,7 @@ manage things like container crud */
   font-size: 13px;
   inline-size: 100%;
   justify-content: space-between;
+  box-shadow: 0 0 0 1px var(--hr-grey);
 }
 
 #container-info-panel {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -2243,15 +2243,6 @@ Logic.registerPanel(P_CONTAINER_DELETE, {
 
     // Populating the panel: name, icon, and warning message
     document.getElementById("container-delete-title").textContent = identity.name;
-
-    const totalNumberOfTabs = identity.numberOfHiddenTabs + identity.numberOfOpenTabs;
-    let warningMessage = "";
-    if (totalNumberOfTabs > 0) {
-      const grammaticalNumTabs = totalNumberOfTabs > 1 ? "tabs" : "tab";
-      warningMessage = `If you remove this container now, ${totalNumberOfTabs} container ${grammaticalNumTabs} will be closed.`;
-    }
-    document.getElementById("delete-container-tab-warning").textContent = warningMessage;
-
     return Promise.resolve(null);
   },
 });

--- a/src/popup.html
+++ b/src/popup.html
@@ -449,7 +449,7 @@
     </form>
     <div id="permissions-overlay" class="permissions-overlay" data-tab-group="proxy-disabled">
       <p data-tab-group="proxy-disabled" data-i18n-message-id="additionalPermissionNeeded"></p>
-      <button id="enable-proxy-permissions" class="primary-cta" data-tab-group="proxy-disabled">Enable</button>
+      <button id="enable-proxy-permissions" class="primary-cta" data-tab-group="proxy-disabled" data-i18n-message-id="enable"></button>
     </div>
   </div>
   <script src="js/utils.js"></script>

--- a/src/popup.html
+++ b/src/popup.html
@@ -394,7 +394,6 @@
     <hr>
     <div class="panel-content delete-container-confirm">
       <h4 class="delete-container-confirm-title" data-i18n-message-id="removeThisContainer"></h4>
-      <p class="delete-warning" id="delete-container-tab-warning"></p>
       <p class="delete-warning" data-i18n-message-id="removeThisContainerConfirmation"></p>
     </div>
     <div class="panel-footer">


### PR DESCRIPTION
We missed a string in the delete container panel during internationalization. After reviewing this screen, I think we should remove this string altogether and possibly consider implementing something more helpful as a follow-up (perhaps showing the titles of open tabs, pulling relevant tabs into a new window so the user doesn't have to potentially go hunting through their open tabs to find them, something else...), or replacing this with a single generic "Tabs open in this Container will be closed" flag.

Fixes Jira ticket MAC-698