### PR TITLE
return single ProxyInfo object when advanced proxy

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -198,7 +198,7 @@ window.assignManager = {
     }
 
     if (!result.proxy.mozProxyEnabled) {
-      return [{ ...result.proxy, proxyDNS: true }];
+      return { ...result.proxy, proxyDNS: true };
     }
 
     // Let's add the isolation key.


### PR DESCRIPTION
To test:

0. Run Mozilla VPN
1. Change to this branch of code
2. Run the extension (`web-ext run -s src`)
3. Create a container and make it use a Mozilla VPN proxy
4. In the vpn container, go to https://mullvad.net/en/ and make sure the top banner shows the vpn location you expect
5. In the vpn container, go to https://www.dnsleaktest.com/ and make sure it shows the vpn location you expect
6. Create a container using an advanced proxy setting (e.g., `socks://au3-wg.socks5.mullvad.net:1080`)
4. In the advanced proxy container, go to https://mullvad.net/en/ and make sure the top banner shows the proxy location you expect
5. In the advanced proxy container, go to https://www.dnsleaktest.com/ and make sure it shows the proxy location you expect
4. In a NON-container tab, go to https://mullvad.net/en/ and make sure the top banner shows the proxy location you expect
5. In a NON-container tab, go to https://www.dnsleaktest.com/ and make sure it shows the proxy location you expect
