### PR TITLE
Honor the "don't ask again" checkbox when use of the assigned container is *denied*

### DIFF
--- a/src/confirm-page.html
+++ b/src/confirm-page.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">

--- a/src/js/background/index.html
+++ b/src/js/background/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">

--- a/src/js/confirm-page.js
+++ b/src/js/confirm-page.js
@@ -42,6 +42,7 @@ function confirmSubmit(redirectUrl, cookieStoreId) {
     browser.runtime.sendMessage({
       method: "neverAsk",
       neverAsk: true,
+      forceContainer: true,
       pageUrl: redirectUrl
     });
   }
@@ -56,6 +57,16 @@ function getCurrentTab() {
 }
 
 async function denySubmit(redirectUrl) {
+  const neverAsk = document.getElementById("never-ask").checked;
+  // Sending neverAsk message to background to store for next time we see this process
+  if (neverAsk) {
+    browser.runtime.sendMessage({
+      method: "neverAsk",
+      neverAsk: true,
+      forceContainer: false,
+      pageUrl: redirectUrl
+    });
+  }
   const tab = await getCurrentTab();
   await browser.runtime.sendMessage({
     method: "exemptContainerAssignment",

--- a/src/pageActionPopup.html
+++ b/src/pageActionPopup.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">


### PR DESCRIPTION
My rough attempt at remembering to stay in the original container when the checkbox "don't ask again" is **checked**, but use of the assigned container is **denied**. Fixes #1730

This is done by introducing a new site setting `forceContainer`, which indicates what decision was made by the user when they passed through the confirmation page with the "don't ask again" checkbox checked: `true` (default) if they confirmed the use of the assigned container and, conversely, `false` if they denied it.

> ⚠ One possibly undesirable side effect — it doesn't seem possible to open websites assigned to containers in the default container anymore. At all. I would love to differentiate tabs opened from the OS from the ones opened explicitly, but I don't know how hard that is right now.

> 🚧  I haven't wrapped my head around Mocha and the mocks in use here, so no tests yet, thus it's a draft. Any help with this or other implementation improvements are most welcome! 🙌

> ➕ And I also added `<!DOCTYPE html>`s all over the HTMLs to get rid of the Quirks Mode warnings. Open to extracting into another PR if there's a need for that!