### PR TITLE
Remove maxlength from proxy settings

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -299,7 +299,7 @@
           <legend class="form-header" data-i18n-message-id="icon"></legend>
         </fieldset>
         <fieldset class="proxies"> <!---- PROXIES -->
-          <input type="text" class="proxies" name="container-proxy" id="edit-container-panel-proxy" maxlength="50" placeholder="type://host:port" hidden/>
+          <input type="text" class="proxies" name="container-proxy" id="edit-container-panel-proxy" placeholder="type://host:port" hidden/>
           <input type="text" class="proxies" name="moz-proxy-enabled" id="moz-proxy-enabled" maxlength="5" hidden/>
           <input type="text" class="proxies" name="country-code" id="country-code-input" maxlength="5" hidden/>
           <input type="text" class="proxies" name="city-name" id="city-name-input" maxlength="5" hidden/>
@@ -440,7 +440,7 @@
     <form class="advanced-proxy-panel-content">
       <label class="advanced-proxy-input-label" for="container-proxy" data-i18n-message-id="advancedProxySettings"></label>
       <div class="advanced-proxy-input-wrapper">
-        <input id="edit-advanced-proxy-input" class="proxy-host primary-input" name="container-proxy" type="text" maxlength="50" placeholder="type://host:port" />
+        <input id="edit-advanced-proxy-input" class="proxy-host primary-input" name="container-proxy" type="text" placeholder="type://host:port" />
         <button id="clear-advanced-proxy-input" class="controller" data-i18n-attribute="value" data-i18n-attribute-message-id="clearproxylabel"></button>
         <span class="proxy-validity" data-i18n-message-id="invalidProxyAlert"></span>
       </div>


### PR DESCRIPTION
Per my #2295 issue, the UI limits the total proxy input length to 50 characters which is insufficient in the case of credentials or long domain names. This PR simply removes the `maxlength` property completely as there is no upper bound should someone have a very long username and/or password.