### PR TITLE
Handle any response as signal that the mvpn-bridge is present

### DIFF
--- a/src/js/background/mozillaVpnBackground.js
+++ b/src/js/background/mozillaVpnBackground.js
@@ -66,11 +66,11 @@ const MozillaVPN_Background = {
 
   // Handle responses from MozillaVPN client
   async handleResponse(response) {
+    MozillaVPN_Background._installed = true;
     if (response.error && response.error === "vpn-client-down") {
       MozillaVPN_Background._connected = false;
       return;
     }
-    MozillaVPN_Background._installed = true;
     if (response.servers) {
       const servers = response.servers.countries;
       browser.storage.local.set({ [MozillaVPN_Background.MOZILLA_VPN_SERVERS_KEY]: servers});


### PR DESCRIPTION
Closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3128
The reason for this bug is a race - Depending on how fast you open the mac panel between accepting the permission prompt. 
Just after initialization, the extension sends this to the bridge:
```       
this.postToApp("status");
this.postToApp("servers");
```
The response to each is: 
```{ error: "vpn-client-down" }```  

Which will cause the handleResponse to set ```_connected=false``` but leave ```_installed=undefined```. (thus showing the panel)
However as the bridge in the meantime will fail to open a connection to the client it will periodically send for each failed attempt
``` { status: "vpn-client-down" } ```  
Which means we will set ``` installed=true``` the first time the bridge either connects or fails to connect, instead of the first response we get from it. So i think having the bridge answer the ext should be signal enough that the vpn-package is installed :) 


