### PR TITLE
Make "default container" entry keyboard navigable

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1244,6 +1244,7 @@ Logic.registerPanel(REOPEN_IN_CONTAINER_PICKER, {
     if (currentTab.cookieStoreId !== "firefox-default") {
       const tr = document.createElement("tr");
       tr.classList.add("menu-item", "hover-highlight", "keyboard-nav");
+      tr.setAttribute("tabindex", "0");
       const td = document.createElement("td");
 
       td.innerHTML = Utils.escaped`


### PR DESCRIPTION
Allows selecting "default container" in "reopen this site in" identity picker using keyboard