### PR TITLE
Wildcard subdomains v2 - e.g. *.google.com

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1596,6 +1596,14 @@ manage things like container crud */
   padding-inline-start: 16px;
 }
 
+#edit-sites-assigned .hostname .subdomain:hover {
+  text-decoration: underline;
+}
+
+#edit-sites-assigned .hostname .subdomain.wildcardSubdomain {
+  opacity: 0.2;
+}
+
 .assigned-sites-list > div {
   display: flex;
   padding-block-end: 6px;

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -45,6 +45,9 @@ const messageHandler = {
         // m.url is the assignment to be removed/added
         response = assignManager._setOrRemoveAssignment(m.tabId, m.url, m.userContextId, m.value);
         break;
+      case "setWildcardHostnameForAssignment":
+        response = assignManager._setWildcardHostnameForAssignment(m.url, m.wildcardHostname);
+        break;
       case "sortTabs":
         backgroundLogic.sortTabs();
         break;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1407,10 +1407,11 @@ Logic.registerPanel(P_CONTAINER_ASSIGNMENTS, {
         trElement.innerHTML = Utils.escaped`
         <td>
           <div class="favicon"></div>
-          <span title="${site.hostname}" class="menu-text">${site.hostname}</span>
+          <span title="${site.hostname}" class="menu-text hostname"></span>
           <img class="trash-button delete-assignment" src="/img/container-delete.svg" />
         </td>`;
         trElement.getElementsByClassName("favicon")[0].appendChild(Utils.createFavIconElement(assumedUrl));
+        trElement.querySelector(".hostname").appendChild(this.assignmentHostnameElement(site));
         const deleteButton = trElement.querySelector(".trash-button");
         Utils.addEnterHandler(deleteButton, async () => {
           const userContextId = Logic.currentUserContextId();
@@ -1420,10 +1421,89 @@ Logic.registerPanel(P_CONTAINER_ASSIGNMENTS, {
           delete assignments[siteKey];
           this.showAssignedContainers(assignments);
         });
+        // Wildcard click-to-toggle subdomains
+        trElement.querySelectorAll(".subdomain").forEach((subdomainLink) => {
+          subdomainLink.addEventListener("click", async (e) => {
+            const wildcardHostname = e.target.getAttribute("data-wildcardHostname");
+            Utils.setWildcardHostnameForAssignment(assumedUrl, wildcardHostname);
+            if (wildcardHostname) {
+              // Remove wildcard from other site that has same wildcard
+              Object.values(assignments).forEach((site) => {
+                if (site.wildcardHostname === wildcardHostname) { delete site.wildcardHostname; }
+              });
+              site.wildcardHostname = wildcardHostname;
+            } else {
+              delete site.wildcardHostname;
+            }
+            this.showAssignedContainers(assignments);
+          });
+        });
         trElement.classList.add("menu-item", "hover-highlight", "keyboard-nav");
         tableElement.appendChild(trElement);
       });
     }
+  },
+
+  getSubdomains(site) {
+    const hostname = site.hostname;
+    const wildcardHostname = site.wildcardHostname;
+    if (wildcardHostname && wildcardHostname !== hostname) {
+      if (hostname.endsWith(wildcardHostname)) {
+        return {
+          wildcard: hostname.substring(0, hostname.length - wildcardHostname.length),
+          remaining: wildcardHostname
+        };
+      } else {
+        // In case something got corrupted, allow user to fix error
+        // by clicking "____" link to clear corrupted wildcard hostname
+        return {
+          wildcard: "___",
+          remaining: hostname
+        };
+      }
+    } else {
+      return {
+        wildcard: null,
+        remaining: hostname
+      };
+    }
+  },
+
+  assignmentHostnameElement(site) {
+    const result = document.createElement("span");
+    const subdomains = this.getSubdomains(site);
+
+    // Add wildcard subdomain(s)
+    if (subdomains.wildcard) {
+      result.appendChild(this.assignmentSubdomainLink(null, subdomains.wildcard));
+    }
+
+    // Add non-wildcard subdomains
+    let remainingHostname = subdomains.remaining;
+    let indexOfDot;
+    while ((indexOfDot = remainingHostname.indexOf(".")) >= 0) {
+      const subdomain = remainingHostname.substring(0, indexOfDot);
+      remainingHostname = remainingHostname.substring(indexOfDot + 1);
+      result.appendChild(this.assignmentSubdomainLink(remainingHostname, subdomain));
+      result.appendChild(document.createTextNode("."));
+    }
+
+    // Root domain
+    if (remainingHostname) { result.appendChild(document.createTextNode(remainingHostname)); }
+
+    return result;
+  },
+
+  assignmentSubdomainLink(wildcardHostnameOnClick, text) {
+    const result = document.createElement("a");
+    result.className = "subdomain";
+    if (wildcardHostnameOnClick) {
+      result.setAttribute("data-wildcardHostname", wildcardHostnameOnClick);
+    } else {
+      result.classList.add("wildcardSubdomain");
+    }
+    result.appendChild(document.createTextNode(text));
+    return result;
   },
 });
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -138,6 +138,14 @@ const Utils = {
     });
   },
 
+  setWildcardHostnameForAssignment(url, wildcardHostname) {
+    return browser.runtime.sendMessage({
+      method: "setWildcardHostnameForAssignment",
+      url,
+      wildcardHostname
+    });
+  },
+
   async reloadInContainer(url, currentUserContextId, newUserContextId, tabIndex, active) {
     return await browser.runtime.sendMessage({
       method: "reloadInContainer",

--- a/test/features/wildcard.test.js
+++ b/test/features/wildcard.test.js
@@ -1,0 +1,76 @@
+const {initializeWithTab} = require("../common");
+
+describe("Wildcard Subdomains Feature", function () {
+  const url1 = "http://www.example.com";
+  const url2 = "http://zzz.example.com";
+  const wildcardHostname = "example.com";
+
+  beforeEach(async function () {
+    this.webExt = await initializeWithTab({
+      cookieStoreId: "firefox-container-4",
+      url: url1
+    });
+    await this.webExt.popup.helper.clickElementById("always-open-in");
+    await this.webExt.popup.helper.clickElementByQuerySelectorAll("#picker-identities-list > .menu-item");
+  });
+
+  afterEach(function () {
+    this.webExt.destroy();
+  });
+
+  describe("open new Tab with different subdomain in the default container", function () {
+    beforeEach(async function () {
+      // new Tab opening url2 in default container
+      await this.webExt.background.browser.tabs._create({
+        cookieStoreId: "firefox-default",
+        url: url2
+      }, {
+        options: {
+          webRequestError: true // because request is canceled due to reopening
+        }
+      });
+    });
+
+    it("should not open the confirm page", async function () {
+      this.webExt.background.browser.tabs.create.should.not.have.been.called;
+    });
+
+    it("should not remove the new Tab that got opened in the default container", function () {
+      this.webExt.background.browser.tabs.remove.should.not.have.been.called;
+    });
+  });
+
+  describe("set wildcard hostname and then open new Tab with different subdomain in the default container", function () {
+    let newTab;
+    beforeEach(async function () {
+      // Set wildcard
+      await this.webExt.background.window.assignManager._setWildcardHostnameForAssignment(url1, wildcardHostname);
+
+      // new Tab opening url2 in default container
+      newTab = await this.webExt.background.browser.tabs._create({
+        cookieStoreId: "firefox-default",
+        url: url2
+      }, {
+        options: {
+          webRequestError: true // because request is canceled due to reopening
+        }
+      });
+    });
+
+    it("should open the confirm page", async function () {
+      this.webExt.background.browser.tabs.create.should.have.been.calledWithMatch({
+        url: "moz-extension://fake/confirm-page.html?" +
+               `url=${encodeURIComponent(url2)}` +
+               `&cookieStoreId=${this.webExt.tab.cookieStoreId}`,
+        cookieStoreId: undefined,
+        openerTabId: null,
+        index: 2,
+        active: true
+      });
+    });
+
+    it("should remove the new Tab that got opened in the default container", function () {
+      this.webExt.background.browser.tabs.remove.should.have.been.calledWith(newTab.id);
+    });
+  });
+});


### PR DESCRIPTION
See pull request https://github.com/mozilla/multi-account-containers/pull/1500 and issue https://github.com/mozilla/multi-account-containers/issues/473

This is a second attempt at implementing a wildcard subdomains feature. This time round, I have tried to keep the amount of code that is changing to the bare minimum. This should make code review easier and minimise any risk of introducing regressions. We can potentially cancel the previous pull request if this one looks better.


https://user-images.githubusercontent.com/439593/166697696-78b3d20d-4032-41ac-b030-e017d36a28cb.mov



### How the code works

When you click the `www` part of `www.google.com` in the popup, a `wildcardHostname` property with value `google.com` is added to the stored `siteSettings` object for `www.google.com` in `assignManager.js` [See code here](https://github.com/mckenfra/multi-account-containers/blob/ab400dffdd62e05380b48d5985bd8ce356de5264/src/js/background/assignManager.js#L694)

If you then open a tab and navigate to `mail.google.com`, we need the code to find the matching `google.com` wildcard hostname stored in the `www.google.com` site. This is achieved by storing an additional map of `wildcardHostname` values to `siteStoreKeys`. [See code here](https://github.com/mckenfra/multi-account-containers/blob/ab400dffdd62e05380b48d5985bd8ce356de5264/src/js/background/assignManager.js#L135)
 
So when handling the request for `mail.google.com`, the wildcard hostname map is queried to see if there is a mapping for`mail.google.com`, then `google.com` (and then theoretically `com`). It finds that `google.com` is mapped to `www.google.com`, and so uses the `www.google.com` site settings to handle the request. [See code here](https://github.com/mckenfra/multi-account-containers/blob/ab400dffdd62e05380b48d5985bd8ce356de5264/src/js/background/assignManager.js#L289)

# Syncing

The sync feature should _just work_ as expected, since the new `wildcardHostname` property of the `siteSettings` will be synced along with all the other properties of the `siteSettings` object.

# Try it out

I have put up a temporary build [here](https://github.com/mckenfra/multi-account-containers/releases/tag/8.0.7.1-WildcardSubdomains) for you to try out the feature without having to build it yourself. Let me know if it looks good or if you find any issues.

I have also include unit tests in this pull request.