### PR TITLE
Also allow dots + hyphens in proxy username/password

### DIFF
--- a/src/js/proxified-containers.js
+++ b/src/js/proxified-containers.js
@@ -3,7 +3,7 @@ proxifiedContainers = {
 
   async retrieveAll() {
     const result = await browser.storage.local.get("proxifiedContainersKey");
-    if(!result || !result["proxifiedContainersKey"]) {
+    if (!result || !result["proxifiedContainersKey"]) {
       return null;
     }
 
@@ -12,7 +12,7 @@ proxifiedContainers = {
 
   async retrieve(cookieStoreId) {
     const result = await this.retrieveAll();
-    if(!result) {
+    if (!result) {
       return null;
     }
 
@@ -44,7 +44,7 @@ proxifiedContainers = {
 
   // Parses a proxy description string of the format type://host[:port] or type://username:password@host[:port] (port is optional)
   parseProxy(proxy_str, mozillaVpnData = null) {
-    const proxyRegexp = /(?<type>(https?)|(socks4?)):\/\/(\b(?<username>\w+):(?<password>\w+)@)?(?<host>((?:\d{1,3}\.){3}\d{1,3}\b)|(\b([\w.-]+)+))(:(?<port>\d+))?/;
+    const proxyRegexp = /(?<type>(https?)|(socks4?)):\/\/(\b(?<username>[\w.-]+):(?<password>[\w.-]+)@)?(?<host>((?:\d{1,3}\.){3}\d{1,3}\b)|(\b([\w.-]+)+))(:(?<port>\d+))?/;
     const matches = proxyRegexp.exec(proxy_str);
     if (!matches) {
       return false;
@@ -58,7 +58,10 @@ proxifiedContainers = {
       mozillaVpnData = MozillaVPN.getMozillaProxyInfoObj();
     }
 
-    return {...matches.groups,...mozillaVpnData};
+    return {
+      ...matches.groups,
+      ...mozillaVpnData
+    };
   },
 
   // Deletes the proxy information object for a specified cookieStoreId [useful for cleaning]


### PR DESCRIPTION
Many proxy services add additional configuration options for the proxy in the password (country, city, ttl, etc).

`socks://username:password_country-us_state-newyork_lifetime-24h@host:port
`

I've used the same regex pattern already in use for `host`

<img src="https://user-images.githubusercontent.com/782506/167415430-76aed5f8-88e0-483c-ae37-55bdb28b8eb5.gif" width="400" />