### PR TITLE
Also allow hyphens in proxy username/password

### DIFF
--- a/src/js/proxified-containers.js
+++ b/src/js/proxified-containers.js
@@ -44,7 +44,7 @@ proxifiedContainers = {
 
   // Parses a proxy description string of the format type://host[:port] or type://username:password@host[:port] (port is optional)
   parseProxy(proxy_str, mozillaVpnData = null) {
-    const proxyRegexp = /(?<type>(https?)|(socks4?)):\/\/(\b(?<username>\w+):(?<password>\w+)@)?(?<host>((?:\d{1,3}\.){3}\d{1,3}\b)|(\b([\w.-]+)+))(:(?<port>\d+))?/;
+    const proxyRegexp = /(?<type>(https?)|(socks4?)):\/\/(\b(?<username>[\w-]+):(?<password>[\w-]+)@)?(?<host>((?:\d{1,3}\.){3}\d{1,3}\b)|(\b([\w.-]+)+))(:(?<port>\d+))?/;
     const matches = proxyRegexp.exec(proxy_str);
     if (!matches) {
       return false;


### PR DESCRIPTION
Many proxy services add additional configuration options for the proxy in the password separated by a hyphen (country, city, ttl, etc) like:

 `socks://username:password_country-us_state-newyork_lifetime-24h@host:port`

Causing the proxy to not be saved correctly.

<img src="https://user-images.githubusercontent.com/782506/167415430-76aed5f8-88e0-483c-ae37-55bdb28b8eb5.gif" width="400" />