### PR TITLE
Fix rendering for Troubleshooting info section

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -12,13 +12,6 @@ body:
         - label: "I searched for existing reports to see if it hasn\'t already been reported"
           required: true
   - type: textarea
-    id: about_support
-    attributes:
-      label: "Provide a copy of Troubleshooting Information page"
-      description: "To get a copy of the Troubleshooting Information page, type *about:support* in the address bar and click on the *Copy text to clipboard* button."
-    validations:
-      required: true
-  - type: textarea
     id: step_to_reproduce
     attributes:
       label: "Step to reproduce"
@@ -50,4 +43,11 @@ body:
       description: "Provide any other information revelant to this issue"
     validations:
       required: false
-
+  - type: textarea
+    id: about_support
+    attributes:
+      label: "Provide a copy of Troubleshooting Information page"
+      description: "To get a copy of the Troubleshooting Information page, type *about:support* in the address bar and click on the *Copy text to clipboard* button."
+      render: "plain text"
+    validations:
+      required: true 


### PR DESCRIPTION
This makes sure the troubleshooting section is rendered as plain text instead of markdown. I also moved the section at the end of the form so we don't have to unnecessarily scroll the page to read the other sections. Thanks GitHub for not offering a way to auto-collapse big blocks of code :p. 