### PR TITLE
Fix #2377 Tooltip renders off viewport when hovering over a container assigned to VPN.

### DIFF
--- a/src/js/mozillaVpn.js
+++ b/src/js/mozillaVpn.js
@@ -34,11 +34,8 @@ const MozillaVPN = {
         }
         if (!mozillaVpnConnected && proxy.mozProxyEnabled) {
           flag.classList.add("proxy-unavailable");
-          const tooltip = el.querySelector(".tooltip.proxy-unavailable");
-          if (tooltip) {
-            tooltip.textContent = tooltipProxyWarning;
-          }
           const menuItemName = el.querySelector(".menu-item-name");
+          menuItemName.setAttribute("title", tooltipProxyWarning);
           if (menuItemName) {
             el.querySelector(".menu-item-name").dataset.mozProxyWarning = "proxy-unavailable";
           }
@@ -68,14 +65,11 @@ const MozillaVPN = {
     const mozillaVpnConnected = await browser.runtime.sendMessage({ method: "MozillaVPN_getConnectionStatus" });
     const connectionStatusStringId = mozillaVpnConnected ? "moz-vpn-connected" : "moz-vpn-disconnected";
     const connectionStatusLocalizedString = browser.i18n.getMessage(connectionStatusStringId);
+    const connectionStatusTooltip = document.querySelector(".vpn-status-container-list");
+    connectionStatusTooltip.setAttribute("title", connectionStatusLocalizedString);
 
     statusIconEls.forEach(el => {
       el.style.backgroundImage = mozillaVpnConnected ? connectedIndicatorSrc : disconnectedIndicatorSrc;
-      if (el.querySelector(".tooltip")) {
-        el.querySelector(".tooltip").textContent = connectionStatusLocalizedString;
-      } else {
-        el.textContent = connectionStatusLocalizedString;
-      }
     });
   },
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -789,7 +789,6 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
             </div>
           </div>
           <span class="menu-text">${identity.name}</span>
-          <span class="tooltip proxy-unavailable"></span>
         </div>
         <span class="menu-right-float">
           <img alt="" class="always-open-in-flag flag-img" src="/img/flags/.png"/>

--- a/src/popup.html
+++ b/src/popup.html
@@ -154,7 +154,6 @@
       <div class="sub-header" data-i18n-message-id="containers"></div>
       <h4 class="moz-vpn-logotype vpn-status-container-list display-none">Mozilla VPN
         <span class="moz-vpn-connection-status-indicator container-list-status-icon">
-          <span class="tooltip"></span>
         </span>
       </h4>
     </div>


### PR DESCRIPTION
This patch currently use the built-in tooltip. The rationale for using the bult-in tooltip is:

* a custom solution is more complexe and time consuming to implement
* it's more important that the warning message is seen by the user than the esthetic of it
* we can re-implement a more robust custom tooltip in a follow-up patch