### PR TITLE
Fix #2168 Use a different l10n string for sites opened in no container

### DIFF
--- a/src/confirm-page.html
+++ b/src/confirm-page.html
@@ -23,8 +23,21 @@
       </label>
       <br />
       <div class="button-container">
-        <button id="deny" class="button" data-message-id="openInContainer" data-message-arg="current-container-name"></button>
-        <button id="confirm" class="button primary" autofocus data-message-id="openInContainer" data-message-arg="container-name"></button>
+        <button id="deny"
+                class="button"
+                data-message-id="openInContainer"
+                data-message-arg="current-container-name">
+        </button>
+        <button id="deny-no-container"
+                class="button"
+                data-message-id="openInNoContainer">
+        </button>
+        <button id="confirm"
+                class="button primary"
+                autofocus
+                data-message-id="openInContainer"
+                data-message-arg="container-name">
+        </button>
       </div>
     </form>
   </main>

--- a/src/js/confirm-page.js
+++ b/src/js/confirm-page.js
@@ -12,20 +12,37 @@ async function load() {
     denySubmit(redirectUrl);
   });
 
+  document.getElementById("deny-no-container").addEventListener("click", (e) => {
+    e.preventDefault();
+    denySubmit(redirectUrl);
+  });
+
   const container = await browser.contextualIdentities.get(cookieStoreId);
   const currentContainer = currentCookieStoreId ? await browser.contextualIdentities.get(currentCookieStoreId) : null;
-  const currentContainerName = currentContainer ? currentContainer.name : "";
+  const currentContainerName = currentContainer ? setDenyButton(currentContainer.name) : setDenyButton("");
 
   document.querySelectorAll("[data-message-id]").forEach(el => {
     const elementData = el.dataset;
     const containerName = elementData.messageArg === "container-name" ? container.name : currentContainerName;
     el.textContent = browser.i18n.getMessage(elementData.messageId, containerName);
   });
-  
+
   document.getElementById("confirm").addEventListener("click", (e) => {
     e.preventDefault();
     confirmSubmit(redirectUrl, cookieStoreId);
   });
+}
+
+function setDenyButton(currentContainerName) {
+  const buttonDeny = document.getElementById("deny");
+  const buttonDenyNoContainer = document.getElementById("deny-no-container");
+
+  if (currentContainerName) {
+    buttonDenyNoContainer.style.display = "none";
+    return currentContainerName;
+  }
+  buttonDeny.style.display = "none";
+  return;
 }
 
 function appendFavicon(pageUrl, redirectUrlElement) {


### PR DESCRIPTION
If you assign a website to the Personal container and open the same website in the Work container, it will show you a confirmation page where the left button shows "Open in Work Container". 

However, if the current tab in which you open the website isn't a container, it will show "Open in Container" because the code returns a null value for the container name.

This patch fixes this by showing a different message for this situation by adding a new l10n string (openInNoContainer).