### PR TITLE
Account for moved aboutNetError.css in Firefox 107

### DIFF
--- a/src/confirm-page.html
+++ b/src/confirm-page.html
@@ -2,6 +2,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <title data-i18n-message-id="confirmNavigationTitle"></title>
+  <link xmlns="http://www.w3.org/1999/xhtml" rel="stylesheet" href="chrome://browser/skin/aboutNetError.css" type="text/css" media="all" />
   <link xmlns="http://www.w3.org/1999/xhtml" rel="stylesheet" href="chrome://global/skin/aboutNetError.css" type="text/css" media="all" />
   <script type="text/javascript" src="./js/i18n.js"></script>
   <link rel="stylesheet" href="/css/confirm-page.css" />

--- a/src/confirm-page.html
+++ b/src/confirm-page.html
@@ -2,7 +2,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <title data-i18n-message-id="confirmNavigationTitle"></title>
-  <link xmlns="http://www.w3.org/1999/xhtml" rel="stylesheet" href="chrome://browser/skin/aboutNetError.css" type="text/css" media="all" />
+  <link xmlns="http://www.w3.org/1999/xhtml" rel="stylesheet" href="chrome://global/skin/aboutNetError.css" type="text/css" media="all" />
   <script type="text/javascript" src="./js/i18n.js"></script>
   <link rel="stylesheet" href="/css/confirm-page.css" />
 </head>


### PR DESCRIPTION
Fixes #2423 

This is a fix for the [regression](https://bugzilla.mozilla.org/show_bug.cgi?id=1794329) introduced by [bug 1734217](https://bugzilla.mozilla.org/show_bug.cgi?id=1734217), as it moved the neterror page files from `browser/` to `toolkit/` in m-c, which results in a path change for the `aboutNetError.css` file that the confirm page depends on.