### PR TITLE
Add remove/restore scripts for nested .git folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ README.html
 addon.env
 
 src/web-ext-artifacts/*
+web-ext-artifacts
 
 # JetBrains IDE files
 .idea

--- a/package.json
+++ b/package.json
@@ -36,13 +36,15 @@
     "url": "git+https://github.com/mozilla/multi-account-containers.git"
   },
   "scripts": {
-    "dev": "web-ext run -s src/",
+    "dev": "npm run remove-locales-github && web-ext run -s src/",
     "lint": "npm-run-all lint:*",
     "lint:addon": "./bin/addons-linter.sh",
     "lint:css": "stylelint src/css/*.css",
     "lint:html": "htmllint *.html",
     "lint:js": "eslint .",
     "package": "rm -rf src/web-ext-artifacts && npm run build && mv src/web-ext-artifacts/firefox_multi-account_containers-*.zip addon.xpi",
+    "restore-locales-github": "cd src/_locales && git restore .github/",
+    "remove-locales-github": "rm -rf src/_locales/.github",
     "test": "npm run lint && npm run coverage",
     "test:once": "mocha test/**/*.test.js",
     "test:watch": "npm run test:once -- --watch",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "url": "git+https://github.com/mozilla/multi-account-containers.git"
   },
   "scripts": {
+    "build": "web-ext build -s src/",
     "dev": "npm run remove-locales-github && web-ext run -s src/",
     "lint": "npm-run-all lint:*",
     "lint:addon": "./bin/addons-linter.sh",


### PR DESCRIPTION
## Summary

Add scripts to help dev process

- `dev`: The /src/_locales/.github folder causes `web-ext run` to fail when running the `npm run dev` script. This folder removal isn't tracked or surfaced during local dev work when working from the root directory.
- `build` This script runs `web-ext build`. There was an error when running when running `npm run package` that would call for this missing command. 

## Testing

### `dev` script: 

- Checkout PR
- Run `$ npm run dev`
- **Expected:** The extension should run locally without any console errors

### `build` script:

- Checkout PR
- Run `$ npm run package`
- **Expected:** There should be a new local .zip of the add-on in the `/web-ext-artifacts folder` folder and that file/folder should not be tracked in git. 
- Run `$ git status` to confirm new .zip file is not tracked
