### PR TITLE
🚧 WIP: add ability to remove a container data only

### DIFF
--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -81,6 +81,25 @@ const backgroundLogic = {
     return {done: true, userContextId};
   },
 
+  // Remove container data (cookies, localStorage and cache)
+  async deleteContainerDataOnly(userContextId) {
+    await this._closeTabs(userContextId);
+
+    await browser.browsingData.removeCookies({
+      cookieStoreId: this.cookieStoreId(userContextId)
+    });
+
+    await browser.browsingData.removeLocalStorage({
+      cookieStoreId: this.cookieStoreId(userContextId)
+    });
+
+    await browser.browsingData.removeCache({
+      cookieStoreId: this.cookieStoreId(userContextId)
+    });
+
+    return {done: true, userContextId};
+  },
+
   async createOrUpdateContainer(options) {
     if (options.userContextId !== "new") {
       return await browser.contextualIdentities.update(

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -23,6 +23,9 @@ const messageHandler = {
       case "deleteContainer":
         response = backgroundLogic.deleteContainer(m.message.userContextId);
         break;
+      case "deleteContainerDataOnly":
+        response = backgroundLogic.deleteContainerDataOnly(m.message.userContextId);
+        break;
       case "createOrUpdateContainer":
         response = backgroundLogic.createOrUpdateContainer(m.message);
         break;
@@ -90,10 +93,10 @@ const messageHandler = {
         break;
       case "assignAndReloadInContainer":
         tab = await assignManager.reloadPageInContainer(
-          m.url, 
+          m.url,
           m.currentUserContextId,
-          m.newUserContextId, 
-          m.tabIndex, 
+          m.newUserContextId,
+          m.tabIndex,
           m.active,
           true
         );

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -940,6 +940,19 @@ Logic.registerPanel(P_CONTAINER_INFO, {
       Utils.alwaysOpenInContainer(identity);
       window.close();
     });
+
+    const deleteData = document.querySelector("#delete-data-info-panel");
+    Utils.addEnterHandler(deleteData, async () => {
+      const userContextId = Utils.userContextId(identity.cookieStoreId)
+
+      await browser.runtime.sendMessage({
+        method: "deleteContainerDataOnly",
+        message: { userContextId }
+      });
+
+      window.close();
+    });
+
     // Show or not the has-tabs section.
     for (let trHasTabs of document.getElementsByClassName("container-info-has-tabs")) { // eslint-disable-line prefer-const
       trHasTabs.style.display = !identity.hasHiddenTabs && !identity.hasOpenTabs ? "none" : "";

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,6 +12,7 @@
   "permissions": [
     "<all_urls>",
     "activeTab",
+    "browsingData",
     "cookies",
     "contextMenus",
     "contextualIdentities",

--- a/src/popup.html
+++ b/src/popup.html
@@ -245,6 +245,16 @@
             </span>
         </td>
       </tr>
+      <tr class="menu-item hover-highlight keyboard-nav" id="delete-data" tabindex="0">
+        <td>
+          <img class="menu-icon" alt="" src="" />
+          <span class="menu-text" id="delete-data-info-panel" data-i18n-message-id="alwaysOpenSiteInContainer">
+            Delete data
+          </span>
+            <span class="menu-arrow">
+            </span>
+        </td>
+      </tr>
     </table>
     <hr>
     <div class="sub-header-wrapper">


### PR DESCRIPTION
This adds a option in the info panel that let the user removes the data (cache, cookies and localStorage) for the selected container.

The option is only clickable if there's data associated to the container.

Closes #303 