### PR TITLE
Fix failing test install by replacing $(npm bin) with npx

### DIFF
--- a/bin/addons-linter.sh
+++ b/bin/addons-linter.sh
@@ -32,4 +32,4 @@ rm -rf $TMPDIR/src/_locales/.github || die
 print G "done."
 
 print Y "Running the test..."
-$(npm bin)/addons-linter $TMPDIR/src || die
+npx addons-linter $TMPDIR/src || die


### PR DESCRIPTION
Tests keep failing bc `$(npm bin)` was not setting the correct path to run an executable. 

See this answer for more info: https://stackoverflow.com/a/15157360