### PR TITLE
Add `file:` protocol to non-permissible protocol list

### DIFF
--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -123,7 +123,8 @@ const backgroundLogic = {
     // We can't open these we just have to throw them away
     if (protocol === "about:"
         || protocol === "chrome:"
-        || protocol === "moz-extension:") {
+        || protocol === "moz-extension:"
+        || protocol === "file:") {
       return false;
     }
     return true;


### PR DESCRIPTION
This fixes #2233, see additional notes from my investigation there. Previous unmerged identical PR: https://github.com/mozilla/multi-account-containers/pull/1927.

Here's a screencast of me reproducing the issue, then making this code change and testing the fix:
[Screencast from 02-16-2023 12:56:06 PM.webm](https://user-images.githubusercontent.com/2391118/219449180-ee82b6cf-9011-42a6-8fbf-6e376b2cb1e7.webm)
