### PR TITLE
Fix missing i18n strings in the UI

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -678,7 +678,7 @@ window.assignManager = {
     }
     browser.contextMenus.create({
       id: menuId,
-      title: "Always Open in This Container",
+      title: browser.i18n.getMessage("alwaysOpenSiteInContainer"),
       checked,
       type: "checkbox",
       contexts: ["all"],
@@ -692,13 +692,13 @@ window.assignManager = {
 
     browser.contextMenus.create({
       id: this.MENU_HIDE_ID,
-      title: "Hide This Container",
+      title: browser.i18n.getMessage("hideThisContainer"),
       contexts: ["all"],
     });
 
     browser.contextMenus.create({
       id: this.MENU_MOVE_ID,
-      title: "Move Tabs to a New Window",
+      title: browser.i18n.getMessage("moveTabsToANewWindow"),
       contexts: ["all"],
     });
   },

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -14,6 +14,7 @@ const backgroundLogic = {
   NUMBER_OF_KEYBOARD_SHORTCUTS: 10,
   unhideQueue: [],
   init() {
+
     browser.commands.onCommand.addListener(function (command) {
       if (command === "sort_tabs") {
         backgroundLogic.sortTabs();
@@ -32,6 +33,20 @@ const backgroundLogic = {
 
     browser.permissions.onAdded.addListener(permissions => this.resetPermissions(permissions));
     browser.permissions.onRemoved.addListener(permissions => this.resetPermissions(permissions));
+
+    // Update Translation in Manifest
+    browser.runtime.onInstalled.addListener(this.updateTranslationInManifest);
+    browser.runtime.onStartup.addListener(this.updateTranslationInManifest);
+  },
+
+  updateTranslationInManifest() {
+    for (let index = 0; index < 10; index++) {
+      const ajustedIndex = index + 1; // We want to start from 1 instead of 0 in the UI.
+      browser.commands.update({
+        name: `open_container_${index}`,
+        description: browser.i18n.getMessage("containerShortcut", `${ajustedIndex}`)
+      });
+    }
   },
 
   resetPermissions(permissions) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,80 +41,80 @@
         "default": "Ctrl+Period",
         "mac": "MacCtrl+Period"
       },
-      "description": "Open containers panel"
+      "description": "__MSG_openContainerPanel__"
     },
     "sort_tabs": {
       "suggested_key": {
         "default": "Ctrl+Comma",
         "mac": "MacCtrl+Comma"
       },
-      "description": "Sort tabs by container"
+      "description": "__MSG_sortTabsByContainer__"
     },
     "open_container_0": {
       "suggested_key": {
         "default": "Ctrl+Shift+1"
       },
-      "description": "Container Shortcut 1"
+      "description": "__MSG_containerShortcut__"
     },
     "open_container_1": {
       "suggested_key": {
         "default": "Ctrl+Shift+2"
       },
-      "description": "Container Shortcut 2"
+      "description": "__MSG_containerShortcut__"
     },
     "open_container_2": {
       "suggested_key": {
         "default": "Ctrl+Shift+3"
       },
-      "description": "Container Shortcut 3"
+      "description": "__MSG_containerShortcut__"
     },
     "open_container_3": {
       "suggested_key": {
         "default": "Ctrl+Shift+4"
       },
-      "description": "Container Shortcut 4"
+      "description": "__MSG_containerShortcut__"
     },
     "open_container_4": {
       "suggested_key": {
         "default": "Ctrl+Shift+5"
       },
-      "description": "Container Shortcut 5"
+      "description": "__MSG_containerShortcut__"
     },
     "open_container_5": {
       "suggested_key": {
         "default": "Ctrl+Shift+6"
       },
-      "description": "Container Shortcut 6"
+      "description": "__MSG_containerShortcut__"
     },
     "open_container_6": {
       "suggested_key": {
         "default": "Ctrl+Shift+7"
       },
-      "description": "Container Shortcut 7"
+      "description": "__MSG_containerShortcut__"
     },
     "open_container_7": {
       "suggested_key": {
         "default": "Ctrl+Shift+8"
       },
-      "description": "Container Shortcut 8"
+      "description": "__MSG_containerShortcut__"
     },
     "open_container_8": {
       "suggested_key": {
         "default": "Ctrl+Shift+9"
       },
-      "description": "Container Shortcut 9"
+      "description": "__MSG_containerShortcut__"
     },
     "open_container_9": {
       "suggested_key": {
         "default": "Ctrl+Shift+0"
       },
-      "description": "Container Shortcut 10"
+      "description": "__MSG_containerShortcut__"
     }
   },
   "browser_action": {
     "browser_style": true,
     "default_icon": "img/multiaccountcontainer-16.svg",
-    "default_title": "Multi-Account Containers",
+    "default_title": "Firefox Multi-Account Containers",
     "default_popup": "popup.html",
     "theme_icons": [
       {
@@ -127,7 +127,7 @@
   "page_action": {
     "browser_style": true,
     "default_icon": "img/container-openin-16.svg",
-    "default_title": "Always open this in a Container",
+    "default_title": "__MSG_alwaysOpenSiteInContainer__",
     "default_popup": "pageActionPopup.html",
     "pinned": false,
     "show_matches": ["*://*/*"]

--- a/src/pageActionPopup.html
+++ b/src/pageActionPopup.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <title>Multi-Account Containers</title>
+  <title>Firefox Multi-Account Containers</title>
   <script type="text/javascript" src="./js/i18n.js"></script>
   <link rel="stylesheet" type="text/css" href="css/popup.css">
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,7 +1,7 @@
 <html data-theme="auto">
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <title>Multi-Account Containers</title>
+  <title>Firefox Multi-Account Containers</title>
   <script type="text/javascript" src="./js/i18n.js"></script>
   <link rel="stylesheet" href="./css/popup.css">
 </head>
@@ -107,7 +107,7 @@
   </div>
 
   <div class="panel menu-panel container-panel hide" id="container-panel">
-    <h3 class="title">Multi-Account Containers</h3>
+    <h3 class="title">Firefox Multi-Account Containers</h3>
     <a href="#" class="info-icon" id="info-icon" tabindex="10">
       <img data-i18n-attribute-message-id="info" data-i18n-attribute="alt" alt="" src="/img/info.svg" / >
     </a>
@@ -268,7 +268,7 @@
 
   <div class="panel menu-panel container-picker-panel hide" id="container-picker-panel">
     <h3 class="title" id="picker-title">
-      Multi-Account Containers
+      Firefox Multi-Account Containers
     </h3>
     <button class="btn-return arrow-left controller keyboard-nav-back" id="close-container-picker-panel" tabindex="0"></button>
     <hr>


### PR DESCRIPTION
This patch fix all the missing i18n strings in the UI. It also standardize the main title to "Firefox Multi-Account Containers" everywhere we use it in the addon.

In `src/js/background/backgroundLogic.js`, we update the i18n strings for the open_container_[0-9] commands on startup and on install. This is done to avoid using both an hardcoded value with a i18n strings (e.g `__MSG_myMessage__ my extra text`). See https://github.com/mozilla-l10n/multi-account-containers-l10n/pull/23