### PR TITLE
fix: don't preventDefault on modifier keys

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -426,7 +426,6 @@ const Logic = {
 
     if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) {
       isModifierPressed = true;
-      e.preventDefault();
     }
 
     if (Logic._currentPanel === "containersList" && !isModifierPressed && !isSearchInputFocused) {


### PR DESCRIPTION
Fixes #2553

The preventDefault on modifier keys seemed fishy, removing it solved the problem immediately. The digit shortcuts seem to still be working fine.