### PR TITLE
fix: remove broken escape from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,7 +9,7 @@ body:
       options:
         - label: "I updated to the latest version of Multi-Account Container and tested if I can reproduce the issue"
           required: true
-        - label: "I searched for existing reports to see if it hasn\'t already been reported"
+        - label: "I searched for existing reports to see if it hasn't already been reported"
           required: true
   - type: textarea
     id: step_to_reproduce


### PR DESCRIPTION
Currently, clicking on 'New Issue' in the issues tab doesn't show the option to actually create an issue because the template is broken (maybe this is a problem with github's parsing?) with the following error:

![image](https://github.com/mozilla/multi-account-containers/assets/2374520/6f7157bf-2f5b-42da-b9de-72ed09f855e5)

(screenshot from https://github.com/mozilla/multi-account-containers/blob/main/.github/ISSUE_TEMPLATE/bug.yml )

Removing the backslash before a single quote fixes the issue. Even if the issue is with GitHub's parsing, the backslash is redundant anyway.

You can test this on my fork: https://github.com/leodag/multi-account-containers/issues/new/choose