### PR TITLE
Small fixes

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -61,8 +61,9 @@ window.assignManager = {
         this.area.get([siteStoreKey]).then((storageResponse) => {
           if (storageResponse && siteStoreKey in storageResponse) {
             resolve(storageResponse[siteStoreKey]);
+          } else {
+            resolve(null);
           }
-          resolve(null);
         }).catch((e) => {
           reject(e);
         });

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -639,7 +639,7 @@ window.assignManager = {
   },
 
   async _maybeRemoveSiteIsolation(userContextId) {
-    const assignments = await this.storageArea.getByContainer(userContextId);
+    const assignments = await this.storageArea.getAssignedSites(userContextId);
     const hasAssignments = assignments && Object.keys(assignments).length > 0;
     if (hasAssignments) {
       return;


### PR DESCRIPTION
I was going over the code to look at writing up some PRs and stumbled across 2 small easily corrected issues:
- a Promise’s `resolve()` being called twice, which is meaningless.  
  Note that I’ve checked that using else for fallback/function exit is OK per style, see e.g. https://github.com/mozilla/multi-account-containers/blob/60b40a2d9f609572bd55fd59f7206ff4680365ef/src/js/background/assignManager.js#L16-L20
- A function call to `getByContainer()` which doesn’t exist (there is a `getAssignedSites()` which in turn calls `_getByContainer()`)