### PR TITLE
Add MAC icon in toolbar on install

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -116,6 +116,7 @@
     "default_icon": "img/multiaccountcontainer-16.svg",
     "default_title": "Firefox Multi-Account Containers",
     "default_popup": "popup.html",
+    "default_area": "navbar",
     "theme_icons": [
       {
         "light": "img/multiaccountcontainer-16-dark.svg",


### PR DESCRIPTION
This manifest.json option ensures that the MAC icon is shown in the toolbar after installation. This is needed since the Unified Extension Button has been implemented in Firefox.