### PR TITLE
Revert monitoring modifier in popup shortcuts

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -420,16 +420,7 @@ const Logic = {
       isSearchInputFocused = true;
     }
 
-    // We also monitor if a modifier key is pressed simultaneously with a digit
-    // between 0-9 to avoid conflicts with Firefox or other addons.
-    let isModifierPressed = false;
-
-    if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) {
-      isModifierPressed = true;
-      e.preventDefault();
-    }
-
-    if (Logic._currentPanel === "containersList" && !isModifierPressed && !isSearchInputFocused) {
+    if (Logic._currentPanel === "containersList" && !isSearchInputFocused) {
       switch(e.code) {
       case "Digit0":
       case "Digit1":


### PR DESCRIPTION
# Description

Fix a regression in our shortcut listener. The previous patch was listening if a modifier was pressed in order to prevent conflicts with Firefox builtin shortcuts. However, the implementation had a side effect of preventing the insertion of characters from a key combination including a modifier.

Note: The conflict with Firefox builtin shortcuts existed prior to both the patch already landed in main and this fix so it doesn't remove any functionality. 

## Type of change

*Select all that apply.*

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)
