### PR TITLE
Firefox Accounts Rebrand (Dot Release) 

### DIFF
--- a/bin/addons-linter.sh
+++ b/bin/addons-linter.sh
@@ -32,4 +32,4 @@ rm -rf $TMPDIR/src/_locales/.github || die
 print G "done."
 
 print Y "Running the test..."
-$(npm bin)/addons-linter $TMPDIR/src || die
+npx addons-linter $TMPDIR/src || die

--- a/bin/build-addon.sh
+++ b/bin/build-addon.sh
@@ -23,4 +23,4 @@ if [[ $# -gt 0 ]]; then
   EXTRA_PARAMS="--filename $1"
 fi
 
-$(npm bin)/web-ext build --overwrite-dest $EXTRA_PARAMS || die
+npx web-ext build --overwrite-dest $EXTRA_PARAMS || die

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "testpilot-containers",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testpilot-containers",
   "title": "Multi-Account Containers",
   "description": "Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "author": "Andrea Marchesini, Luke Crouch, Lesley Norton, Kendall Werts, Maxx Crawford, Jonathan Kingston",
   "bugs": {
     "url": "https://github.com/mozilla/multi-account-containers/issues"

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -640,7 +640,7 @@ Logic.registerPanel(P_ONBOARDING_7, {
     // Let's move to the containers list panel.
     Utils.addEnterHandler(document.querySelector("#sign-in"), async () => {
       browser.tabs.create({
-        url: "https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=multi-account-containers&utm_source=addon&utm_medium=panel&utm_campaign=container-sync",
+        url: "https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=multi-account-containers&utm_source=addon&utm_medium=panel&utm_campaign=container-sync&brand=mozilla",
       });
       await Logic.setOnboardingStage(7);
       Logic.showPanel(P_ONBOARDING_8);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Multi-Account Containers",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "incognito": "not_allowed",
   "description": "__MSG_extensionDescription__",
   "icons": {

--- a/src/options.html
+++ b/src/options.html
@@ -40,7 +40,7 @@
           </div>
         </div>
       </div>
-      <h3 data-i18n-message-id="firefoxAccountsSync"></h3>
+      <h3 data-i18n-message-id="sync"></h3>
       <div class="settings-group">
         <label>
           <input type="checkbox" id="syncCheck">

--- a/src/popup.html
+++ b/src/popup.html
@@ -44,7 +44,7 @@
   <div class="panel onboarding onboarding-panel-6 hide" id="onboarding-panel-6">
     <img class="onboarding-img" alt="" src="/img/Sync.svg" />
     <h3 class="onboarding-title" data-i18n-message-id="onboarding-6-header"></h3>
-    <p data-i18n-message-id="onboarding-6-description"></p>
+    <p data-i18n-message-id="onboarding-6-description-2"></p>
     <div class="half-button-wrapper">
       <a href="#" id="no-sync" class="half-onboarding-button grey-button keyboard-nav" tabindex="0" data-i18n-message-id="notNow"></a>
       <a href="#" id="start-sync-button" class="half-onboarding-button keyboard-nav" tabindex="0" data-i18n-message-id="startSyncing"></a>
@@ -53,8 +53,8 @@
 
   <div class="panel onboarding onboarding-panel-7 hide" id="onboarding-panel-7">
     <img class="onboarding-img" alt="" src="/img/Account.svg" />
-    <h3 class="onboarding-title" data-i18n-message-id="onboarding-7-header"></h3>
-    <p data-i18n-message-id="onboarding-7-description"></p>
+    <h3 class="onboarding-title" data-i18n-message-id="onboarding-7-header-2"></h3>
+    <p data-i18n-message-id="onboarding-7-description-2"></p>
     <div class="half-button-wrapper">
       <a href="#" id="no-sign-in" class="half-onboarding-button grey-button keyboard-nav" tabindex="0" data-i18n-message-id="notNow"></a>
       <a href="#" id="sign-in" class="half-onboarding-button keyboard-nav" tabindex="0" data-i18n-message-id="signIn"></a>


### PR DESCRIPTION
- FXA Rebrand 60466258b8d91046ee91bc21df2811506e8afeac
- Bump version number to 8.1.3

Testing steps: (See screenshots for more context)
- Run add-on
- Open panel (Go through onboarding)
- **Expected:** On Syncing panel (Panel 6), there should be no mention of "Firefox"
- Click "Start Syncing"
- **Expected:** On this panel,  there should be no mention of "Firefox"
- Close Panel
- Open MAC Settings page (in `about:addons`)
- **Expected:** The Synchronization section should not mention "Firefox"  


## Screenshots

<img width="390" alt="image" src="https://github.com/mozilla/multi-account-containers/assets/2692333/d9cedf4a-3430-44d7-8b4c-4fe749961c23">

<img width="404" alt="image" src="https://github.com/mozilla/multi-account-containers/assets/2692333/558764bb-e661-466d-80a1-1e8998ad389a">

<img width="728" alt="image" src="https://github.com/mozilla/multi-account-containers/assets/2692333/14d58bd4-1e74-4f0e-ab6e-df06282cafcd">

