### PR TITLE
Use `/usr/bin/env` to find bash

### DIFF
--- a/bin/addons-linter.sh
+++ b/bin/addons-linter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/bin/build-addon.sh
+++ b/bin/build-addon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/bin/commons.sh
+++ b/bin/commons.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

This enables `npm test` to successfully call scripts in `bin/` with the `bash` binary specified by `PROFILE`.

---

Additional information:

In addition to potentially preferring an alternative version of bash than the one in `/bin/bash`, some distributions forego storing bash in `bin/` at all, such as `NixOS`:

```bash
$ cat /etc/os-release | rg '^NAME=' -r ''
NixOS
$ which bash
/run/current-system/sw/bin/bash
```

## Type of change

*Select all that apply.*

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* n/a

Related pull requests:

* https://github.com/mozilla/multi-account-containers/commit/83687f63246e93400cc52d1cd6b854c949d40a3b