### PR TITLE
Fix #1958 - Propagate container list reordering in Firefox menus

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -211,6 +211,11 @@ const Logic = {
   async saveContainerOrder(rows) {
     const containerOrder = {};
     rows.forEach((node, index) => {
+      if (typeof browser.contextualIdentities.move === "function") {
+        browser.contextualIdentities.move(
+          node.dataset.containerId, index);
+      }
+
       return containerOrder[node.dataset.containerId] = index;
     });
     await browser.storage.local.set({


### PR DESCRIPTION


**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

Since Fx 123, we have a new API (contextualIdentities.move) that let us reorder the container list everywhere in Firefox. This patch looks if the API is supported by the client and propagate the change if it's the case.

## Type of change

*Select all that apply.*

- [ ] Bug fix
- [x] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* #1958 
