### PR TITLE
Make "Remember my decision for this site" checkbox useful even when pressing deny button

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -622,7 +622,7 @@ window.assignManager = {
   },
 
   async _maybeRemoveSiteIsolation(userContextId) {
-    const assignments = await this.storageArea.getByContainer(userContextId);
+    const assignments = await this._getByContainer(userContextId);
     const hasAssignments = assignments && Object.keys(assignments).length > 0;
     if (hasAssignments) {
       return;

--- a/src/js/confirm-page.js
+++ b/src/js/confirm-page.js
@@ -74,6 +74,23 @@ function getCurrentTab() {
 
 async function denySubmit(redirectUrl) {
   const tab = await getCurrentTab();
+  const neverAsk = document.getElementById("never-ask").checked;
+  
+  if (neverAsk) {
+    const searchParams = new URL(window.location).searchParams;
+    const currentCookieStoreId = searchParams.get("currentCookieStoreId");
+    
+    await browser.runtime.sendMessage({
+      method: "setOrRemoveAssignment",
+      tabId: tab[0].id,
+      url: redirectUrl,
+      userContextId: currentCookieStoreId ? Utils.userContextId(
+        currentCookieStoreId
+      ) : false,
+      value: !currentCookieStoreId,
+    });
+  }
+
   await browser.runtime.sendMessage({
     method: "exemptContainerAssignment",
     tabId: tab[0].id,


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

When you try to open an assigned site in a container to which it is not assigned, or in no container at all, the "confirm-page" shows up:

![image](https://github.com/mozilla/multi-account-containers/assets/78160019/469abbbb-0b02-4bc4-9cb1-69289ca05af1)

In this page, the "Remember my decision for this site" checkbox is only useful if you press the blue "Open in {container-name} container" button, but does nothing if you press the gray button.

This PR makes the checkbox useful for when you press the gray button, changing the site's assigned container to the one you were trying to open it in, or removing the site's assignment if you wanted to open the site in a no-container tab and checked the checkbox.

Aside from that, I fixed a bug where a nonexistent method `storageArea.getByContainer` was called in assignManager.js, once this was breaking my changes (this is apparently also fixed in the #2572 PR).

## Type of change

*Select all that apply.*

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* #2612 
