### PR TITLE
Allow disabling the onboarding panel from enterprise policies

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -81,11 +81,31 @@ const Logic = {
     }
 
     // Routing to the correct panel.
-    // If localStorage is disabled, we don't show the onboarding.
+    //
+    // We do not show the onboarding panel when:
+    // 1. localStorage is disabled
+    // 2. `disableOnboarding` is set to `true` in the enterprise policies
     const onboardingData = await browser.storage.local.get([ONBOARDING_STORAGE_KEY]);
     let onboarded = onboardingData[ONBOARDING_STORAGE_KEY];
     if (!onboarded) {
       onboarded = 9;
+      this.setOnboardingStage(onboarded);
+    }
+
+    // If a polices file or a key in it do not exists, an error is raised.
+    // As a workaround, we catch and ignore the error if there is one. See
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1868153
+    let disableOnboarding = false;
+    try {
+      const managedStorage =
+        await browser.storage.managed.get("disableOnboarding");
+      disableOnboarding = managedStorage.disableOnboarding;
+    } catch(e) {
+      // ignore error
+    }
+
+    if (disableOnboarding) {
+      onboarded = 8;
       this.setOnboardingStage(onboarded);
     }
 


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

Allow disabling the onboarding panel from enterprise policies.

policies.json example:

```
{
  "policies": {
    "3rdparty": {
      "Extensions": {
        "@testpilot-containers": {
	  "disableOnboarding": true
	}
      }
    }
  }
}
```

Note: I didn't implement a policy to disable only the feature to connect to Mozilla VPN as requested because I prefer to do it in a separated patch.

## Type of change

*Select all that apply.*

- [ ] Bug fix
- [x] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* #2565 

## Additional information

cc'ing @mkaply for a review on this too.