### PR TITLE
Fix page load for proxied containers when Mozilla VPN isn't active (fix #2570)

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -198,6 +198,10 @@ window.assignManager = {
       return {};
     }
 
+    if (!MozillaVPN_Background.getInstallationStatus() || !MozillaVPN_Background.getConnectionStatus()) {
+      return {};
+    }
+
     // proxyDNS only works for SOCKS proxies
     if (["socks", "socks4"].includes(result.proxy.type)) {
       result.proxy.proxyDNS = true;


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

Remove the use of the proxy if Mozilla VPN inactive, still load page in the dedicated container. Without this fix, infinite page load happen on custom location proxied containers if Mozilla VPN is inactive (more info on #2570).

## To reproduce:
- Assign a custom VPN location to a container.
- Globally disable Mozilla VPN.
- Open a page with this container.
- The page will load indefinitely.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Major change (fix or feature that would cause existing functionality to work differently than in the current version)
  - The container will not use proxy even if it is configured to work behind a proxy when Mozilla VPN is inactive (globally disabled or not installed).

Tag issues related to this pull request:

* #2570
