### PR TITLE
Fix bz#1823729 - Listen only for status on tab updated

### DIFF
--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -90,10 +90,10 @@ const messageHandler = {
         break;
       case "assignAndReloadInContainer":
         tab = await assignManager.reloadPageInContainer(
-          m.url, 
+          m.url,
           m.currentUserContextId,
-          m.newUserContextId, 
-          m.tabIndex, 
+          m.newUserContextId,
+          m.tabIndex,
           m.active,
           true
         );
@@ -220,7 +220,9 @@ const messageHandler = {
           // if it's a container tab wait for it to complete and
           // unhide other tabs from this container
           if (tab.cookieStoreId.startsWith("firefox-container")) {
-            browser.tabs.onUpdated.addListener(this.tabUpdateHandler);
+            browser.tabs.onUpdated.addListener(this.tabUpdateHandler, {
+              properties: ["status"]
+            });
           }
         }
       }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1823729#c9

**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [ ] I ran `npm test` and all tests passed.
- [ ] I added test coverages if relevant.

# Description

tl;dr If a tab never reach the complete readyState, we can end up in a situation where a frequent (and likely never ending?) sequence of tabs.onUpdated events are triggered. This can create performance issues in a session with a large amount of tabs. By only tracking the onUpdated events we really need, we can considerably reduce the numbers of events and prevent any performance issues.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1823729#c9



## Type of change

*Select all that apply.*

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* [Bugzilla 1823729](https://bugzilla.mozilla.org/show_bug.cgi?id=1823729)
*
*
