### PR TITLE
#1309 add confirm sorting dialoge

### DIFF
--- a/src/js/content-script.js
+++ b/src/js/content-script.js
@@ -45,3 +45,10 @@ async function addMessage(message) {
 browser.runtime.onMessage.addListener((message) => {
   addMessage(message);
 });
+
+browser.runtime.onMessage.addListener(message => {
+  if (message.action === 'confirmSortDialogue') {
+    const result = confirm("confirm sorting tabs");
+    return Promise.resolve({result});
+  }
+});

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -756,16 +756,22 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
     Utils.addEnterHandler(document.querySelector("#always-open-in"), () => {
       Logic.showPanel(ALWAYS_OPEN_IN_PICKER);
     });
+    
     Utils.addEnterHandler(document.querySelector("#sort-containers-link"), async () => {
-      try {
-        await browser.runtime.sendMessage({
-          method: "sortTabs"
-        });
-        window.close();
-      } catch (e) {
-        window.close();
+
+      const [tab] = await browser.tabs.query({currentWindow: true, active: true});
+    
+      // sort without dialouge if active page dosent have content script
+      if(!/^(https?|wss?|file):/.test(tab.url)) {
+        browser.runtime.sendMessage({method: "sortTabs"});
+        return;
       }
+    
+      const {result} = await browser.tabs.sendMessage(tab.id, {action: 'confirmSortDialogue'});
+      if(result)browser.runtime.sendMessage({method: "sortTabs"});
+      window.close();
     });
+    
 
     const mozillaVpnToutName = "moz-tout-main-panel";
     const mozillaVpnPermissionsWarningDotName = "moz-permissions-warning-dot";


### PR DESCRIPTION
Hello everyone!
This is my first pull request on GitHub, and I’d greatly appreciate your feedback.

Feature: Adds confirmation before sorting tabs (#1309).
Before: Clicking the sort button instantly sorts all open tabs.
After: A confirm() dialog is shown before sorting, and tabs are sorted only if "Yes" is selected.

How it works:

1)The user triggers the action in popup.js.
2)A message is sent to contentscript.js to display the dialog.
3)If the content script is not allowed on the page, it skips the dialog and directly sorts the tabs.
4)contentscript.js responds with true or false.
5)Based on the response, popup.js proceeds with sorting or stops.

Issue: I'm not receiving any response from contentscript.js, so I’m unable to proceed.

Looking forward to your feedback—thanks in advance!


