### PR TITLE
Update CI actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -26,7 +26,7 @@ jobs:
           ./bin/build-addon.sh nightly.xpi
 
       - name: Uploading
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: ${{matrix.config.name}} Build
             path: src/web-ext-artifacts


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

The CI build job in my other [PR  ](https://github.com/mozilla/multi-account-containers/pull/2722)fails as it's loading a deprecated GH action, this pr should just fix that, given none of the behavior changes in 
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md apply to this usage. 

## Type of change

*Select all that apply.*

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)
