### PR TITLE
feat: redirect disable basic

### DIFF
--- a/bin/addons-linter.sh
+++ b/bin/addons-linter.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testpilot-containers",
-  "version": "8.1.3",
+  "version": "8.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "testpilot-containers",
-      "version": "8.1.1",
+      "version": "8.2.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "addons-linter": "^5.28.0",
@@ -15032,8 +15032,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -17246,15 +17245,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.0.2.tgz",
       "integrity": "sha512-Pry0S9YmHoz8NCEMRQh7N0Yexh2MYCNPIlrV52hTmS7qXnTghWsjXouF08bgsrrZqaW9tt1ZiK3j5NEmPE+EjQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-promise": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
       "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -19763,8 +19760,7 @@
           "version": "7.5.9",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
           "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -21971,8 +21967,7 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-value-parser": {
       "version": "4.2.0",
@@ -22826,8 +22821,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "slash": {
       "version": "3.0.0",
@@ -23571,8 +23565,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
       "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-standard": {
       "version": "20.0.0",
@@ -24946,8 +24939,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
       "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xdg-basedir": {
       "version": "5.1.0",

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -225,14 +225,16 @@ window.assignManager = {
       return {};
     }
     this.removeContextMenu();
-    let [tab, siteSettings] = await Promise.all([
+    const a = await Promise.all([
       browser.tabs.get(options.tabId),
       this.storageArea.get(options.url)
     ]);
+    const tab = a[0];
+    let siteSettings = a[1];
     let container = false;
     let cookieStoreId = false;
     if (siteSettings) {
-      cookieStoreId = backgroundLogic.cookieStoreId(siteSettings.userContextId)
+      cookieStoreId = backgroundLogic.cookieStoreId(siteSettings.userContextId);
     }
     try {
       container = cookieStoreId && await browser.contextualIdentities

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -225,14 +225,18 @@ window.assignManager = {
       return {};
     }
     this.removeContextMenu();
-    const [tab, siteSettings] = await Promise.all([
+    let [tab, siteSettings] = await Promise.all([
       browser.tabs.get(options.tabId),
       this.storageArea.get(options.url)
     ]);
-    let container;
+    let container = false;
+    let cookieStoreId = false;
+    if (siteSettings) {
+      cookieStoreId = backgroundLogic.cookieStoreId(siteSettings.userContextId)
+    }
     try {
-      container = await browser.contextualIdentities
-        .get(backgroundLogic.cookieStoreId(siteSettings.userContextId));
+      container = cookieStoreId && await browser.contextualIdentities
+        .get(cookieStoreId);
     } catch (e) {
       container = false;
     }
@@ -242,6 +246,14 @@ window.assignManager = {
     if (siteSettings && !container) {
       this.deleteContainer(siteSettings.userContextId);
       return {};
+    }
+
+    if (siteSettings && container) {
+      const containerState = await identityState.storageArea.get(cookieStoreId);
+      if (containerState.redirectDisable) {
+        container = false;
+        siteSettings = null;
+      }
     }
     const userContextId = this.getUserContextIdFromCookieStore(tab);
 
@@ -392,7 +404,8 @@ window.assignManager = {
     // Requested page is not assigned to a specific container. If the current tab's container
     // is locked, then the page must be reloaded in the default container.
     const currentContainerState = await identityState.storageArea.get(tab.cookieStoreId);
-    return currentContainerState && currentContainerState.isIsolated;
+    return currentContainerState && currentContainerState.isIsolated &&
+      !currentContainerState.redirectDisable;
   },
 
   maybeAddProxyListeners() {

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -215,6 +215,16 @@ const backgroundLogic = {
     }
   },
 
+  async setRedirectState(cookieStoreId, enable) {
+    const containerState = await identityState.storageArea.get(cookieStoreId);
+    try {
+      containerState.redirectDisable = !enable
+      return await identityState.storageArea.set(cookieStoreId, containerState);
+    } catch (error) {
+      // console.error(`No container: ${cookieStoreId}`);
+    }
+  },
+
   async moveTabsToWindow(options) {
     const requiredArguments = ["cookieStoreId", "windowId"];
     this.checkArgs(requiredArguments, options, "moveTabsToWindow");
@@ -321,7 +331,8 @@ const backgroundLogic = {
         hasOpenTabs: !!openTabs.length,
         numberOfHiddenTabs: containerState.hiddenTabs.length,
         numberOfOpenTabs: openTabs.length,
-        isIsolated: !!containerState.isIsolated
+        isIsolated: !!containerState.isIsolated,
+        redirectDisable: containerState.redirectDisable
       };
       return;
     });

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -218,7 +218,7 @@ const backgroundLogic = {
   async setRedirectState(cookieStoreId, enable) {
     const containerState = await identityState.storageArea.get(cookieStoreId);
     try {
-      containerState.redirectDisable = !enable
+      containerState.redirectDisable = !enable;
       return await identityState.storageArea.set(cookieStoreId, containerState);
     } catch (error) {
       // console.error(`No container: ${cookieStoreId}`);

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -63,6 +63,9 @@ const messageHandler = {
           windowId: m.windowId
         });
         break;
+      case "setRedirectState":
+        response = backgroundLogic.setRedirectState(m.cookieStoreId, m.state);
+        break;
       case "checkIncompatibleAddons":
         // TODO
         break;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -258,6 +258,7 @@ const Logic = {
         identity.numberOfHiddenTabs = stateObject.numberOfHiddenTabs;
         identity.numberOfOpenTabs = stateObject.numberOfOpenTabs;
         identity.isIsolated = stateObject.isIsolated;
+        identity.redirectDisable = stateObject.redirectDisable;
       }
       if (containerOrder) {
         identity.order = containerOrder[identity.cookieStoreId];
@@ -998,6 +999,7 @@ Logic.registerPanel(P_CONTAINER_INFO, {
     }
 
     this.intializeShowHide(identity);
+    this.initializeRedirectSwitch(identity);
 
     // Let's retrieve the list of tabs.
     const tabs = await browser.runtime.sendMessage({
@@ -1019,6 +1021,27 @@ Logic.registerPanel(P_CONTAINER_INFO, {
     return this.buildOpenTabTable(tabs);
   },
 
+  initializeRedirectSwitch(identity) {
+    const redirectEl = document.querySelector("#disable-redirect");
+    Utils.addEnterHandler(redirectEl, async () => {
+      try {
+        browser.runtime.sendMessage({
+          method: "setRedirectState",
+          state: identity.redirectDisable,
+          cookieStoreId: Logic.currentCookieStoreId()
+        });
+        window.close();
+      } catch (e) {
+        window.close();
+      }
+    });
+
+    // const hideShowIcon = document.getElementById("container-info-hideorshow-icon");
+    // hideShowIcon.src = identity.hasHiddenTabs ? CONTAINER_UNHIDE_SRC : CONTAINER_HIDE_SRC;
+
+    const redirectLabel = document.getElementById("disable-redirect-this-container");
+    redirectLabel.textContent = browser.i18n.getMessage(identity.redirectDisable ?   "enableRedirectThisContainer" : "disableRedirectThisContainer");
+  },
   intializeShowHide(identity) {
     const hideContEl = document.querySelector("#hideorshow-container");
     if (identity.numberOfOpenTabs === 0 && !identity.hasHiddenTabs) {

--- a/src/popup.html
+++ b/src/popup.html
@@ -247,6 +247,14 @@
             </span>
         </td>
       </tr>
+      <tr class="menu-item hover-highlight keyboard-nav" id="disable-redirect" tabindex="0">
+        <td>
+          <img class="menu-icon" alt="" src="/img/disable-redirect.svg" />
+          <span class="menu-text" id="disable-redirect-this-container" data-i18n-message-id="disableRedirectThisContainer"></span>
+            <span class="menu-arrow">
+            </span>
+        </td>
+      </tr>
       <tr class="menu-item hover-highlight keyboard-nav" id="clear-container-storage" tabindex="0">
         <td>
           <img class="menu-icon clear-storage-icon" alt="" src="img/container-delete.svg" />


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [ ] I added test coverages if relevant.

# Description

Workaround for #2706

This PR is intend to add a switch to disable redirection of a container.
When redirection is disable, the new tab will not automacally,
open in that container, or open outside the container.

The tab will just stay in its current container.

### Draft
This PR is still a draft though it work now.
I will finish other details if this workaround is acceptable.
(eg: Add a new icon and globally disable redirection)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* #2706 

