### PR TITLE
Fix #2747: open/reopen container tabs in tab groups when appropriate

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -1,11 +1,3 @@
-/**
- * Firefox does not yet have the `tabGroups` API, which exposes this constant
- * to indicate that a tab is not in a tab group. But the Firefox `tabs` API
- * currently returns this constant value for `Tab.groupId`.
- * @see https://searchfox.org/mozilla-central/rev/3b95c8dbe724b10390c96c1b9dd0f12c873e2f2e/browser/components/extensions/schemas/tabs.json#235
- */
-const TAB_GROUP_ID_NONE = -1;
-
 window.assignManager = {
   MENU_ASSIGN_ID: "open-in-this-container",
   MENU_REMOVE_ID: "remove-open-in-this-container",
@@ -777,7 +769,7 @@ window.assignManager = {
    * @param {number} index
    * @param {boolean} active
    * @param {number} openerTabId
-   * @param {number} [groupId]
+   * @param {number} [groupId] Tab group ID
    * @returns {Promise<Tab>}
    */
   async createTabWrapper(url, cookieStoreId, index, active, openerTabId, groupId) {
@@ -789,7 +781,7 @@ window.assignManager = {
       openerTabId,
     });
 
-    if (groupId && groupId !== TAB_GROUP_ID_NONE && browser.tabs.group) {
+    if (groupId >= 0) {
       // If the original tab was in a tab group, make sure that the reopened tab
       // stays in the same tab group.
       await browser.tabs.group({ groupId, tabIds: newTab.id });

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -91,7 +91,9 @@ const messageHandler = {
           m.newUserContextId,
           m.tabIndex,
           m.active,
-          true
+          true,
+          null,
+          m.groupId
         );
         break;
       case "assignAndReloadInContainer":
@@ -101,7 +103,9 @@ const messageHandler = {
           m.newUserContextId,
           m.tabIndex,
           m.active,
-          true
+          true,
+          null,
+          m.groupId
         );
         // m.tabId is used for where to place the in content message
         // m.url is the assignment to be removed/added

--- a/src/js/confirm-page.js
+++ b/src/js/confirm-page.js
@@ -1,11 +1,3 @@
-/**
- * Firefox does not yet have the `tabGroups` API, which exposes this constant
- * to indicate that a tab is not in a tab group. But the Firefox `tabs` API
- * currently returns this constant value for `Tab.groupId`.
- * @see https://searchfox.org/mozilla-central/rev/3b95c8dbe724b10390c96c1b9dd0f12c873e2f2e/browser/components/extensions/schemas/tabs.json#235
- */
-const TAB_GROUP_ID_NONE = -1;
-
 async function load() {
   const searchParams = new URL(window.location).searchParams;
   const redirectUrl = searchParams.get("url");
@@ -120,10 +112,10 @@ async function openInContainer(redirectUrl, cookieStoreId) {
     cookieStoreId,
     url: redirectUrl
   });
-  if (tab.groupId && tab.groupId !== TAB_GROUP_ID_NONE && browser.tabs.group) {
+  if (tab.groupId >= 0) {
     // If the original tab was in a tab group, make sure that the reopened tab
     // stays in the same tab group.
-    browser.tabs.group({ groupId: tab.groupId, tabIds: reopenedTab.id });
+    await browser.tabs.group({ groupId: tab.groupId, tabIds: reopenedTab.id });
   }
-  browser.tabs.remove(tab.id);
+  await browser.tabs.remove(tab.id);
 }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1306,7 +1306,8 @@ Logic.registerPanel(REOPEN_IN_CONTAINER_PICKER, {
         false,
         newUserContextId,
         currentTab.index + 1,
-        currentTab.active
+        currentTab.active,
+        currentTab.groupId
       );
       window.close();
     };
@@ -1336,7 +1337,8 @@ Logic.registerPanel(REOPEN_IN_CONTAINER_PICKER, {
           false,
           0,
           currentTab.index + 1,
-          currentTab.active
+          currentTab.active,
+          currentTab.groupId
         );
         window.close();
       });

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -94,6 +94,9 @@ const Utils = {
     return result.join("");
   },
 
+  /**
+   * @returns {Promise<Tab|false>}
+   */
   async currentTab() {
     const activeTabs = await browser.tabs.query({ active: true, windowId: browser.windows.WINDOW_ID_CURRENT });
     if (activeTabs.length > 0) {
@@ -146,14 +149,24 @@ const Utils = {
     });
   },
 
-  async reloadInContainer(url, currentUserContextId, newUserContextId, tabIndex, active) {
+  /**
+   * @param {string} url
+   * @param {string} currentUserContextId
+   * @param {string} newUserContextId
+   * @param {number} tabIndex
+   * @param {boolean} active
+   * @param {number} [groupId]
+   * @returns {Promise<any>}
+   */
+  async reloadInContainer(url, currentUserContextId, newUserContextId, tabIndex, active, groupId = undefined) {
     return await browser.runtime.sendMessage({
       method: "reloadInContainer",
       url,
       currentUserContextId,
       newUserContextId,
       tabIndex,
-      active
+      active,
+      groupId
     });
   },
 
@@ -167,7 +180,8 @@ const Utils = {
         currentUserContextId: false,
         newUserContextId: assignedUserContextId,
         tabIndex: currentTab.index +1,
-        active:currentTab.active
+        active: currentTab.active,
+        groupId: currentTab.groupId
       });
     }
     await Utils.setOrRemoveAssignment(


### PR DESCRIPTION
- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [ ] I added test coverages if relevant.

# Description

Fixes #2747

Firefox 137 introduced tab groups. Tab group web extension support is rolling out in Firefox 138 and later. Creating a new tab after the last tab in a tab group can inadvertently create the new tab outside of the tab group.

When a user opens a new tab that should be in a container, this patch will make sure that the new tab resides in the same tab group as the original tab.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* #2747
