### PR TITLE
Increase eslint ecmaVersion to 2021

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2021
   },
   "env": {
     "browser": true,


### PR DESCRIPTION
- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

CONTRIBUTING.md specifies the minimum supported Firefox version as 91.1.0.

Based on the caniuse.com data for ECMAScript features listed at https://gist.github.com/Julien-Marcou/156b19aea4704e1d2f48adafc6e2acbf, I determined the following minimum Firefox versions that support each ECMAScript version:

- ECMAScript 2018 (current setting) = Firefox 78
- ECMAScript 2019 = Firefox 64
- ECMAScript 2020 = Firefox 80
- ECMAScript 2021 = Firefox 79
- ECMAScript 2022 = Firefox 92
- ECMAScript 2023 = Firefox 104
- ECMAScript 2024 = Firefox 119+ (not exactly sure)

This project is using v7 of eslint which depends on v7 of espree for JavaScript parsing. espree v7 has a maximum ECMAScript support version of ECMAScript 2021.

Based on these findings, increasing the configured `parser.ecmaVersion` from `2018` to `2021` will allow using all JavaScript syntax supported in Firefox 91.1.0+ without raising eslint errors.

## Type of change

Development/internal
