### PR TITLE
Remove suggested key for `sort_tabs`

### DIFF
--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -52,23 +52,19 @@ const backgroundLogic = {
    *
    * @param {{reason: runtime.OnInstalledReason, previousVersion?: string}} details
    */
-  _undoDefault820SortTabsKeyboardShortcut(details) {
+  async _undoDefault820SortTabsKeyboardShortcut(details) {
     if (details.reason === "update" && details.previousVersion === "8.2.0") {
-      browser.commands.getAll().then((commands) => {
-        const sortTabsCommand = commands.find(command => command.name === "sort_tabs");
-        if (sortTabsCommand) {
-          const previouslySuggestedKeys = [
-            "Ctrl+Comma", // "default"
-            "MacCtrl+Comma", // "mac"
-          ];
-          if (previouslySuggestedKeys.includes(sortTabsCommand.shortcut)) {
-            browser.commands.update({
-              name: "sort_tabs",
-              shortcut: "",
-            });
-          }
+      const commands = await browser.commands.getAll();
+      const sortTabsCommand = commands.find(command => command.name === "sort_tabs");
+      if (sortTabsCommand) {
+        const previouslySuggestedKeys = [
+          "Ctrl+Comma", // "default"
+          "MacCtrl+Comma", // "mac"
+        ];
+        if (previouslySuggestedKeys.includes(sortTabsCommand.shortcut)) {
+          browser.commands.reset("sort_tabs");
         }
-      }).catch(err => console.error(err));
+      }
     }
   },
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -45,10 +45,6 @@
       "description": "__MSG_openContainerPanel__"
     },
     "sort_tabs": {
-      "suggested_key": {
-        "default": "Ctrl+Comma",
-        "mac": "MacCtrl+Comma"
-      },
       "description": "__MSG_sortTabsByContainer__"
     },
     "open_container_0": {


### PR DESCRIPTION
- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [ ] I added test coverages if relevant.

# Description

Remove suggested keyboard shortcut for the `sort_tabs` operation. For users updating from v8.2.0 of this addon, clear the `sort_tabs` keyboard shortcut if the configured keyboard shortcut is the default suggested key (Ctrl + Comma) from 8.2.0.

A number of users have accidentally pressed Ctrl + Comma and sorted their tabs by container. For some of those users, they did not know what had happened. See some of the following: #1309, #2731

#2492 added Ctrl + Comma as a default shortcut key for sorting tabs by container. This change was released with addon v8.2.0 in Sept 2024.

It is useful to make the sort-tabs-by-container operation accessible by keyboard shortcut, but I think Ctrl + Comma is too close to the main Ctrl + Period shortcut for this addon. I think it's reasonable to make the default sort_tabs keyboard shortcut more complex, but in this patch, I'm recommending that we:

1. do not set a shortcut by default for any future users. Users can still configure a shortcut via Firefox's Manage Extension Shortcuts UI.
2. for existing users upgrading from 8.2.0 who configured their own, non-default keyboard shortcut for sort_tabs, keep their shortcut in place. These users demonstrated a strong interest in using the sort_tabs feature and I do not want to interfere.
3. for existing users upgrading from 8.2.0 who have the default keyboard shortcut configured, clear the shortcut. Users who did not use the sort_tabs keyboard shortcut will no longer be at risk of accidentally using it. Users who did use the default sort_tabs keyboard shortcut will be harmed, but those users can use the Manage Extension Shortcuts UI to manually configure Ctrl + Comma (or another key combination).

I am not aware of any simple ways to ensure that existing users using Ctrl + Comma can continue to do so without interruption. Ideally, I think #2492 should not have set a suggested key -- the other keyboard shortcuts are "non-destructive" and easy to understand. However, since that already happened, I think the best harm reduction approach at this point is to inconvenience existing users of Ctrl + Comma.

## Type of change

I'm not sure how to categorize this. Since this will cause some users relying on Ctrl + Comma to be unable to sort tabs by keyboard shortcut until they take an extra action to configure one in Manage Extension Shortcuts, it's kind of like a breaking change. But in principle, I think of this more like a bug fix that improves the default behavior of a feature that is otherwise not changing.
