### PR TITLE
Version upgrade 8.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testpilot-containers",
   "title": "Multi-Account Containers",
   "description": "Containers helps you keep all the parts of your online life contained in different tabs. Custom labels and color-coded tabs help keep different activities — like online shopping, travel planning, or checking work email — separate.",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "author": "Andrea Marchesini, Luke Crouch, Lesley Norton, Kendall Werts, Maxx Crawford, Jonathan Kingston",
   "bugs": {
     "url": "https://github.com/mozilla/multi-account-containers/issues"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Multi-Account Containers",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "incognito": "not_allowed",
   "description": "__MSG_extensionDescription__",
   "icons": {


### PR DESCRIPTION
Firefox Multi-Account Containers 8.3.0

## IMPORTANT NOTE

Version 8.2.0 of this add-on configured Ctrl + Comma as the default keyboard shortcut for sorting the tab strip by container. This keyboard shortcut was removed from 8.3.0 in patch #2758. If you use Ctrl + Comma in order to quickly sort tabs by container, then you will need to explicitly reconfigure the keyboard shortcut. https://support.mozilla.org/en-US/kb/manage-extension-shortcuts-firefox

## Features
- #2753 Avoid sorting tabs in Firefox tab groups
- #2758 Removed suggested keyboard shortcut for tab sorting
- #2722 Removed Mozilla VPN logo banner

## Bugs
- #2572 Fixed add/remove site assignments logic bug
- #2754 Fixed "open/reopen in container" bug that would reopen outside of a Firefox tab group
- #2760 Removed console log spam related to context menu cleanup

## Developer
- #2671 Updated contributor documentation with tips and corrected links
- #2723 Updated GitHub Actions build image