### PR TITLE
Add data collection permissions to manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,11 +31,13 @@
     "proxy"
   ],
   "browser_specific_settings": {
-    "gecko": {
-      "id": "@testpilot-containers",
-      "strict_min_version": "91.1.0"
+  "gecko": {
+    "id": "@testpilot-containers",
+    "data_collection_permissions": {
+      "required": ["none"]
     }
-  },
+  }
+},
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {


### PR DESCRIPTION
### What Changed
- Added `"data_collection_permissions": { "required": ["none"] }` under 
  `"browser_specific_settings.gecko"` in `manifest.json`.

### Why
Mozilla now requires extensions to explicitly declare their data collection 
permissions (see: https://blog.mozilla.org/addons/2025/05/09/new-extension-data-consent-experience-now-available-in-firefox-nightly/).
This update ensures compliance with the new policy and makes clear that the 
extension does not collect any user data.

### Notes
- No functional changes to the extension itself.
- This update is solely to satisfy Mozilla’s new data collection requirements.
