### PR TITLE
Use `/usr/bin/env` instead of `/bin/env`

### DIFF
--- a/bin/addons-linter.sh
+++ b/bin/addons-linter.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/bin/build-addon.sh
+++ b/bin/build-addon.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/bin/commons.sh
+++ b/bin/commons.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [ ] I added test coverages if relevant.

# Description

In #2599, the shebang for the scripts in the `bin` directory changed to `/bin/env`, even though the commit message says they were changed to use `/usr/bin/env`. `/usr/bin/env bash` is the correct portable shebang to use, as `env` is in `/usr/bin` (not `/bin`) on most Unix-like systems.

## Type of change

*Select all that apply.*

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)
