### PR TITLE
feat: add manual URL input to container site assignments panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ addon.env
 src/web-ext-artifacts/*
 web-ext-artifacts
 
-# JetBrains IDE files
+# IDE files
 .idea
+.vscode
 
 # IstanbulJS
 .nyc_output

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1830,6 +1830,84 @@ manage things like container crud */
   padding-inline-start: 16px;
 }
 
+.add-site-form {
+  padding-block: 8px;
+  padding-inline: 16px;
+}
+
+.add-site-input-wrapper {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+#add-site-input {
+  flex: 1;
+  font-size: 12px;
+  font-family: var(--fontInter);
+  border: 1px solid var(--input-border-color, #ccc);
+  border-radius: 4px;
+  padding-block: 5px;
+  padding-inline: 8px;
+  background: var(--input-bg-color, #fff);
+  color: var(--text-color-primary, #000);
+  outline: none;
+}
+
+#add-site-input:focus {
+  border-color: var(--blue-60, #0060df);
+}
+
+.add-site-button {
+  flex-shrink: 0;
+  inline-size: 24px;
+  block-size: 24px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-color-secondary, #737373);
+  cursor: pointer;
+  position: relative;
+  padding: 0;
+}
+
+.add-site-button::before,
+.add-site-button::after {
+  content: "";
+  position: absolute;
+  background: currentColor;
+  border-radius: 1px;
+  inset-inline-start: 50%;
+  inset-block-start: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.add-site-button::before {
+  inline-size: 12px;
+  block-size: 2px;
+}
+
+.add-site-button::after {
+  inline-size: 2px;
+  block-size: 12px;
+}
+
+.add-site-button:hover {
+  background: var(--grey-20, #ededf0);
+  color: var(--blue-60, #0060df);
+}
+
+.add-site-error {
+  display: block;
+  font-size: 11px;
+  color: var(--red-60, #d70022);
+  padding-block-start: 4px;
+}
+
+.add-site-error.hide {
+  display: none;
+}
+
 .assigned-sites-list > div {
   display: flex;
   padding-block-end: 6px;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1427,7 +1427,60 @@ Logic.registerPanel(P_CONTAINER_ASSIGNMENTS, {
   panelSelector: "#edit-container-assignments",
 
   // This method is called when the object is registered.
-  initialize() {  },
+  initialize() {
+    const addSiteButton = document.getElementById("add-site-button");
+    const addSiteInput = document.getElementById("add-site-input");
+
+    const addSite = async () => {
+      const errorEl = document.getElementById("add-site-error");
+      errorEl.classList.add("hide");
+      errorEl.textContent = "";
+
+      let hostname = addSiteInput.value.trim();
+      if (!hostname) {
+        return;
+      }
+
+      // Strip protocol if user pasted a full URL
+      try {
+        if (hostname.includes("://")) {
+          hostname = new URL(hostname).hostname;
+        } else if (hostname.includes("/")) {
+          hostname = new URL("https://" + hostname).hostname;
+        }
+      } catch {
+        errorEl.textContent = "Invalid URL";
+        errorEl.classList.remove("hide");
+        return;
+      }
+
+      // Basic hostname validation
+      if (!hostname || hostname.length < 1 || !hostname.includes(".")) {
+        errorEl.textContent = "Invalid hostname";
+        errorEl.classList.remove("hide");
+        return;
+      }
+
+      const userContextId = Logic.currentUserContextId();
+      const fakeUrl = `https://${hostname}`;
+
+      await Utils.setOrRemoveAssignment(false, fakeUrl, userContextId, false);
+
+      addSiteInput.value = "";
+
+      // Refresh the list
+      const assignments = await Logic.getAssignmentObjectByContainer(userContextId);
+      this.showAssignedContainers(assignments);
+    };
+
+    Utils.addEnterHandler(addSiteButton, addSite);
+    addSiteInput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        addSite();
+      }
+    });
+  },
 
   // This method is called when the panel is shown.
   async prepare() {

--- a/src/popup.html
+++ b/src/popup.html
@@ -399,6 +399,18 @@
     <h3 class="title" id="edit-assignments-title" data-i18n-message-id="default"></h3>
     <button class="btn-return arrow-left controller" id="close-container-assignment-panel"></button>
     <hr>
+    <div class="add-site-form">
+      <div class="add-site-input-wrapper">
+        <input type="text"
+               id="add-site-input"
+               name="add-site-input"
+               placeholder="example.com"
+               data-i18n-attribute="placeholder"
+               data-i18n-attribute-message-id="addSitePlaceholder">
+        <button id="add-site-button" class="add-site-button" aria-label="Add site"></button>
+      </div>
+      <span id="add-site-error" class="add-site-error hide"></span>
+    </div>
     <div class="scrollable edit-sites-assigned">
       <div class="sub-header" data-i18n-attribute-message-id="sitesAssignedToThisContainer"></div>
       <table class="menu scrollable" id="edit-sites-assigned">


### PR DESCRIPTION
**Before submitting your pull request**
- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [ ] I added test coverages if relevant.

# Description

Currently, assigning a site to a container requires navigating to that site first, then using "Always open in this container". This is inconvenient when you want to set up multiple assignments upfront without visiting each site.

This PR adds a manual URL input field in the "Manage Site List" panel (accessible from a container's edit view). Users can now type or paste a hostname (e.g. `github.com`) or a full URL (e.g. `https://github.com/settings`) and it will be parsed, validated, and assigned to the current container — all without leaving the popup.

Changes:
- `src/popup.html`: added input + button in the assignments panel
- `src/js/popup.js`: added hostname parsing/validation logic, calls existing `setOrRemoveAssignment` API
- `src/css/popup.css`: styled the input and a minimal pure-CSS "+" icon button consistent with the existing UI
- `.gitignore`: added `.vscode` to IDE files section

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* Addresses the need for manual site-to-container assignment without navigation