### PR TITLE
fix: Update MDN links to new URL format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,4 +51,4 @@ If you run into an issue, you can always ask the other community members in the 
 [issues]: https://github.com/mozilla/multi-account-containers/issues
 [l10n]: https://github.com/mozilla-l10n/multi-account-containers-l10n/
 [pr]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
-[web-ext]: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext
+[web-ext]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Getting_started_with_web-ext

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -316,7 +316,7 @@ const backgroundLogic = {
       newWindowObj = await browser.windows.create();
 
       // Pin the default tab in the new window so existing pinned tabs can be moved after it.
-      // From the docs (https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/move):
+      // From the docs (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/move):
       //   Note that you can't move pinned tabs to a position after any unpinned tabs in a window, or move any unpinned tabs to a position before any pinned tabs.
       await browser.tabs.update(newWindowObj.tabs[0].id, { pinned: true });
 


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates 2 broken MDN links:
- `/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext` → `/en-US/docs/Mozilla/Add-ons/WebExtensions/Getting_started_with_web-ext`
- `/en-US/Add-ons/WebExtensions/API/tabs/move` → `/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/move`

This is a proven merge type for Mozilla-related repos.
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*