### PR TITLE
Fix broken MDN link (developer.mozilla.org/en-US/Add-ons → /en-US/docs/Mozilla/Add-ons)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,4 +51,4 @@ If you run into an issue, you can always ask the other community members in the 
 [issues]: https://github.com/mozilla/multi-account-containers/issues
 [l10n]: https://github.com/mozilla-l10n/multi-account-containers-l10n/
 [pr]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
-[web-ext]: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext
+[web-ext]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Getting_started_with_web-ext


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates the old MDN link to use the new path structure.

Old: developer.mozilla.org/en-US/Add-ons/...
New: developer.mozilla.org/en-US/docs/Mozilla/Add-ons/...


---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
