### PR TITLE
Fix #2699: Prevent trashcan from being obscured by scrollbar

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -309,9 +309,9 @@ table {
   transition: opacity 0s;
 }
 
-/* effect borrowed from tabs in firefox, ensure that the element flexes to the full width */
+/* Allow flex item to shrink below content size for proper text truncation */
 .truncate-text {
-  inline-size: calc(100vw - 100px);
+  min-inline-size: 0;
   overflow: hidden;
   position: relative;
   white-space: nowrap;


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the MPL 2.0 license.
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [ ] I added test coverages if relevant.

# Description

When users have "Always show scrollbars" enabled in their OS settings, the trashcan (delete) and reset buttons on assigned site list rows are partly hidden behind the visible scrollbar.

**Root cause:** `.truncate-text` used `inline-size: calc(100vw - 100px)`, which bases the width on the full viewport — including the area consumed by the scrollbar. This forced the text span to a fixed width that overflows the flex container when a scrollbar is present, pushing the action buttons behind it.

**Fix:** Replace the fixed `calc()` width with `min-inline-size: 0`, which is the standard CSS fix for allowing flex items to shrink below their content size. The parent `<td>` already uses `display: flex` and `.menu-text` already has `flex: 1`, so the text span now naturally fills only the remaining space after the favicon and buttons — regardless of whether a scrollbar is visible.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Major change

Fixes #2699
