### PR TITLE
popup: Exclude "Always open" from menu colors hack.

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -28,6 +28,8 @@
 
 [data-theme="light"],
 :root {
+  color-scheme: light;
+
   --fontInter: "Inter", sans-serif;
   --fontInterMedium: "Inter-Medium", sans-serif;
   --fontMetropolis: "Metropolis", sans-serif;
@@ -113,6 +115,8 @@
 }
 
 [data-theme="dark"] {
+  color-scheme: dark;
+
   --iconCloseX: url("/img/close-light.svg");
   --iconGear: url("/img/gear-icon-light.svg");
   --iconArrowRight: url("/img/arrow-icon-right-light.svg");
@@ -238,7 +242,9 @@ body {
 [data-theme="dark"] img.clear-storage-icon,
 [data-theme="dark"] img.delete-assignment,
 [data-theme="dark"] #edit-sites-assigned .menu-icon,
-[data-theme="dark"] #container-info-table .menu-icon {
+[data-theme="dark"] #container-info-table .menu-icon,
+[data-theme="dark"] #always-open .menu-icon,
+[data-theme="dark"] #always-open-in .menu-icon {
   filter: invert(0);
 }
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -3,6 +3,7 @@
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <title>Firefox Multi-Account Containers</title>
   <script type="text/javascript" src="./js/i18n.js"></script>
+  <meta name="color-scheme" content="light dark">
   <link rel="stylesheet" href="./css/popup.css">
 </head>
 <body>


### PR DESCRIPTION
Since they don't need inverting.

**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [ ] I added test coverages if relevant. (N/A, UI tweak)

# Description

Make sure that color-scheme 

## Type of change

*Select all that apply.*

- [x] Bug fix

Tag issues related to this pull request:

* #2872
