### PR TITLE
Add default/fallback container for unassigned sites

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -264,7 +264,11 @@ window.assignManager = {
     const siteIsolatedReloadInDefault =
       await this._maybeSiteIsolatedReloadInDefault(siteSettings, tab);
 
-    if (!siteIsolatedReloadInDefault) {
+    const fallbackCookieStoreId = (!siteSettings && !siteIsolatedReloadInDefault)
+      ? await this._maybeFallbackContainerCookieStoreId(tab)
+      : null;
+
+    if (!siteIsolatedReloadInDefault && !fallbackCookieStoreId) {
       if (!siteSettings
           || userContextId === siteSettings.userContextId
           || this.storageArea.isExempted(options.url, tab.id)) {
@@ -323,6 +327,15 @@ window.assignManager = {
     if (siteIsolatedReloadInDefault) {
       this.reloadPageInDefaultContainer(
         options.url,
+        tab.index + 1,
+        tab.active,
+        openTabId,
+        tab.groupId
+      );
+    } else if (fallbackCookieStoreId) {
+      this.createTabWrapper(
+        options.url,
+        fallbackCookieStoreId,
         tab.index + 1,
         tab.active,
         openTabId,
@@ -394,6 +407,22 @@ window.assignManager = {
     // is locked, then the page must be reloaded in the default container.
     const currentContainerState = await identityState.storageArea.get(tab.cookieStoreId);
     return currentContainerState && currentContainerState.isIsolated;
+  },
+
+  async _maybeFallbackContainerCookieStoreId(tab) {
+    const { fallbackContainerCookieStoreId } = await browser.storage.local.get("fallbackContainerCookieStoreId");
+    if (!fallbackContainerCookieStoreId) return null;
+    // Already in the fallback container, no redirect needed
+    if (tab.cookieStoreId === fallbackContainerCookieStoreId) return null;
+    // Verify the container still exists
+    try {
+      await browser.contextualIdentities.get(fallbackContainerCookieStoreId);
+      return fallbackContainerCookieStoreId;
+    } catch {
+      // Container was deleted, clean up the setting
+      browser.storage.local.remove("fallbackContainerCookieStoreId");
+      return null;
+    }
   },
 
   maybeAddProxyListeners() {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -59,6 +59,37 @@ async function changeTheme(event) {
   await browser.storage.local.set({currentThemeId: theme.selectedIndex});
 }
 
+async function setupDefaultContainerSelect() {
+  const select = document.querySelector("#defaultContainerSelect");
+  const identities = await browser.contextualIdentities.query({});
+
+  const noneOption = document.createElement("option");
+  noneOption.value = "";
+  noneOption.textContent = browser.i18n.getMessage("defaultContainerNone");
+  select.appendChild(noneOption);
+
+  for (const identity of identities) {
+    const option = document.createElement("option");
+    option.value = identity.cookieStoreId;
+    option.textContent = identity.name;
+    select.appendChild(option);
+  }
+
+  const { fallbackContainerCookieStoreId } = await browser.storage.local.get("fallbackContainerCookieStoreId");
+  if (fallbackContainerCookieStoreId) {
+    select.value = fallbackContainerCookieStoreId;
+  }
+}
+
+async function changeDefaultContainer(event) {
+  const cookieStoreId = event.target.value || null;
+  if (cookieStoreId) {
+    await browser.storage.local.set({ fallbackContainerCookieStoreId: cookieStoreId });
+  } else {
+    await browser.storage.local.remove("fallbackContainerCookieStoreId");
+  }
+}
+
 async function setupOptions() {
   const { syncEnabled } = await browser.storage.local.get("syncEnabled");
   const { replaceTabEnabled } = await browser.storage.local.get("replaceTabEnabled");
@@ -68,6 +99,7 @@ async function setupOptions() {
   document.querySelector("#replaceTabCheck").checked = !!replaceTabEnabled;
   document.querySelector("#changeTheme").selectedIndex = currentThemeId;
   setupContainerShortcutSelects();
+  setupDefaultContainerSelect();
 }
 
 async function setupContainerShortcutSelects () {
@@ -124,6 +156,7 @@ document.addEventListener("DOMContentLoaded", setupOptions);
 document.querySelector("#syncCheck").addEventListener( "change", enableDisableSync);
 document.querySelector("#replaceTabCheck").addEventListener( "change", enableDisableReplaceTab);
 document.querySelector("#changeTheme").addEventListener( "change", changeTheme);
+document.querySelector("#defaultContainerSelect").addEventListener("change", changeDefaultContainer);
 
 maybeShowPermissionsWarningIcon();
 for (let i=0; i < NUMBER_OF_KEYBOARD_SHORTCUTS; i++) {

--- a/src/options.html
+++ b/src/options.html
@@ -77,6 +77,16 @@
           </select>
       </label></p>
 
+      <h3 data-i18n-message-id="defaultContainer"></h3>
+      <div class="settings-group">
+        <label class="keyboard-shortcut">
+          <span data-i18n-message-id="defaultContainerLabel"></span>
+          <select id="defaultContainerSelect">
+          </select>
+        </label>
+        <p><em data-i18n-message-id="defaultContainerDescription"></em></p>
+      </div>
+
       <h3 data-i18n-message-id="keyboardShortCuts"></h3>
       <p><em data-i18n-message-id="editWhichContainer"></em></p>
 


### PR DESCRIPTION
## Summary

- Adds a **default container** setting: when a site has no specific container assignment, it is automatically opened in a user-configured fallback container.
- New `_maybeFallbackContainerCookieStoreId()` method in `assignManager` reads the setting from storage, verifies the container still exists (auto-cleans if deleted), and returns the target `cookieStoreId`.
- `onBeforeRequest()` redirects to the fallback container when no site assignment matches and the fallback is configured — the tab is replaced cleanly using the existing `createTabWrapper()` path.
- New **"Default container"** section in the options page with a dropdown listing all available containers.

## Test plan

- [ ] Go to **Options → Default container**, select a container (e.g. "Work")
- [ ] Open a new tab and navigate to a site with no assignment — it should reopen in "Work"
- [ ] Navigate to a site that *has* an assignment — it should still open in its assigned container (fallback must not interfere)
- [ ] Sites in a locked (isolated) container still redirect to `firefox-default` as before
- [ ] Delete the container selected as default — the setting is auto-cleaned, no redirect loop
- [ ] Set dropdown back to "No default" — unassigned sites load in whatever container they're in

## Notes

The i18n strings (`defaultContainer`, `defaultContainerLabel`, `defaultContainerDescription`, `defaultContainerNone`) need to be added to the [l10n submodule](https://github.com/mozilla-l10n/multi-account-containers-l10n) separately.

Closes #503 (partial — this implements the catch-all default; always-open-in-no-container is tracked separately in #2860)

🤖 Generated with [Claude Code](https://claude.com/claude-code)