### PR TITLE
options: Make form controls respect color scheme

### DIFF
--- a/src/css/options.css
+++ b/src/css/options.css
@@ -1,3 +1,8 @@
+:root {
+  /* Opt UI chrome such as form controls into user's color scheme. */
+  color-scheme: light dark;
+}
+
 body {
   --grey10: #e7e7e7;
 


### PR DESCRIPTION
- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

I don't think this needs to be tested; it's only aesthetic.

# Description

Every time I used the options I had the feeling something was off with the colours, and I just realised what it is. The `color-scheme` property isn't set, so the form controls default to light theme even if everything else is dark! I have set it to `light dark` at the root level, which means all UI chrome respects the user's colour preference, with "light" being the default.

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/color-scheme

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:
None (I think)
