### PR TITLE
Keep assigned site actions clear of scrollbar

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -283,6 +283,10 @@ table {
   padding-block-end: 8px;
 }
 
+.edit-sites-assigned {
+  scrollbar-gutter: stable;
+}
+
 .offpage {
   opacity: 0;
 }


### PR DESCRIPTION
## Summary
- Reserve a stable scrollbar gutter for the assigned-sites list in the edit container panel.
- Keeps the hover action buttons, including the delete/trash button, clear of the scrollbar when scrollbars are always visible.

Fixes #2699

## Verification
- `npm ci --legacy-peer-deps`
- `npm run lint:css`
- `npm run lint:html`
- `npm run coverage` (22 passing, 1 pending)
- `npm run build`
- `npx addons-linter src/` after temporarily excluding `src/_locales/.github` (0 errors, existing warnings only)

Note: `npm test` on Windows stops at the Unix shell wrapper `./bin/addons-linter.sh`, so I ran the portable checks above directly.