### PR TITLE
fix: http/https proxy authorization

### DIFF
--- a/src/js/proxified-containers.js
+++ b/src/js/proxified-containers.js
@@ -50,6 +50,16 @@ proxifiedContainers = {
       return false;
     }
 
+    if (
+      (matches.groups.type === "http" || matches.groups.type === "https") &&
+      matches.groups.username && matches.groups.password
+    ) {
+      matches.groups.proxyAuthorizationHeader =
+        "Basic " + btoa(matches.groups.username + ":" + matches.groups.password);
+      delete matches.groups.username;
+      delete matches.groups.password;
+    }
+
     if (mozillaVpnData && mozillaVpnData.mozProxyEnabled === undefined) {
       matches.groups.type = null;
     }


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

For `http` and `https` proxies `proxyAuthorizationHeader` must be used instead of `username` and `password` ([mdn](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/ProxyInfo#proxyauthorizationheader))

## Type of change

*Select all that apply.*

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* https://github.com/mozilla/multi-account-containers/issues/2801
