### PR TITLE
Fix error messages when running tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -22,7 +22,7 @@ const webExtensionsJSDOM = require("webextensions-jsdom");
 const manifestPath = path.resolve(path.join(__dirname, "../src/manifest.json"));
 
 const buildDom = async ({background = {}, popup = {}}) => {
-  background = {
+  background = background === false ? false : {
     ...background,
     jsdom: {
       ...background.jsom,
@@ -39,7 +39,7 @@ const buildDom = async ({background = {}, popup = {}}) => {
     }
   };
 
-  popup = {
+  popup = popup === false ? false : {
     ...popup,
     jsdom: {
       ...popup.jsdom,
@@ -52,7 +52,8 @@ const buildDom = async ({background = {}, popup = {}}) => {
     wiring: true,
     sinon: global.sinon,
     background,
-    popup
+    popup,
+    pageActionPopup: false,
   });
 
   webExtension.browser = webExtension.background.browser;
@@ -96,6 +97,10 @@ const initializeWithTab = async (details = {
           });
           window.browser.storage.local.set.resetHistory();
           window.browser.storage.sync.clear();
+
+          // window.matchMedia not supported by jsdom:
+          // https://github.com/jsdom/jsdom/issues/3522
+          window.matchMedia = () => ({ matches: false });
         }
       }
     }

--- a/test/features/assignment.test.js
+++ b/test/features/assignment.test.js
@@ -1,4 +1,4 @@
-const {initializeWithTab} = require("../common");
+const {initializeWithTab, nextTick} = require("../common");
 
 describe("Assignment Reopen Feature", function () {
   const url = "http://example.com";
@@ -18,6 +18,7 @@ describe("Assignment Reopen Feature", function () {
     beforeEach(async function () {
       // popup click to set assignment for activeTab.url
       await this.webExt.popup.helper.clickElementById("always-open-in");
+      await nextTick();
       await this.webExt.popup.helper.clickElementByQuerySelectorAll("#picker-identities-list > .menu-item");
     });
 
@@ -54,6 +55,7 @@ describe("Assignment Comfirm Page Feature", function () {
     let newTab;
     beforeEach(async function () {
       await this.webExt.popup.helper.clickElementById("always-open-in");
+      await nextTick();
       await this.webExt.popup.helper.clickElementByQuerySelectorAll("#picker-identities-list > .menu-item");
 
       // new Tab opening activeTab.url in default container


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

Fixes error messages shown when running `npm run test` due to:

1. `window.matchMedia` is unsupported by `jsdom`
2. Mocked `document` is unavailable when resolving promises in `popup.js` and `pageAction.js` where those promises are started but not awaited

### Error messages example

```
> testpilot-containers@8.3.8 coverage
> nyc --reporter=html --reporter=text mocha test/**/*.test.js --timeout 60000

(node:66431) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)


  Assignment Reopen Feature
    set to 'Always open in' firefox-container-4
TypeError: window.matchMedia is not a function
    at Object.getTheme (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:43:344)
    at Object.applyTheme (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:43:793)
TypeError: window.matchMedia is not a function
    at Object.getTheme (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:43:344)
    at Object.applyTheme (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:43:793)
TypeError: window.matchMedia is not a function
    at Object.getTheme (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:49:344)
    at Object.applyTheme (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:49:793)
TypeError: window.matchMedia is not a function
    at Object.getTheme (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:49:344)
    at Object.applyTheme (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:49:793)
      ✔ should open the page in the assigned container
TypeError: Cannot read properties of undefined (reading 'querySelector')
    at eval (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:81:281)
    at Array.forEach (<anonymous>)
    at Object.showPanel (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:81:115)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
TypeError: Cannot read properties of undefined (reading 'querySelector')
    at eval (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:81:281)
    at Array.forEach (<anonymous>)
    at Object.showPanel (eval at buildDom (multi-account-containers/node_modules/webextensions-jsdom/src/nyc.js:58:16), <anonymous>:81:115)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

## Type of change

*Select all that apply.*

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)
