### PR TITLE
Fix #2910: Memory leak due to not removing exempted tab entries when …

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -101,7 +101,9 @@ window.assignManager = {
 
     async deleteContainer(userContextId) {
       const sitesByContainer = await this.getAssignedSites(userContextId);
-      this.area.remove(Object.keys(sitesByContainer));
+      const siteStoreKeys = Object.keys(sitesByContainer);
+      siteStoreKeys.forEach(siteStoreKey => this.removeExempted(siteStoreKey));
+      this.area.remove(siteStoreKeys);
       identityState.storageArea.remove(backgroundLogic.cookieStoreId(userContextId));
     },
 

--- a/test/issues/2910.test.js
+++ b/test/issues/2910.test.js
@@ -1,0 +1,54 @@
+const {initializeWithTab, nextTick} = require("../common");
+
+describe("#2910", function () {
+  const url = "http://example.com";
+
+  beforeEach(async function () {
+    this.webExt = await initializeWithTab({
+      cookieStoreId: "firefox-default",
+      url
+    });
+    this.initialTabId = this.webExt.tab.id;
+  });
+
+  afterEach(function () {
+    this.webExt.destroy();
+  });
+
+  describe("set to 'Always open in' firefox-container-4", function () {
+    beforeEach(async function () {
+      // popup click to set assignment for activeTab.url
+      await this.webExt.popup.helper.clickElementById("always-open-in");
+      await nextTick();
+      await this.webExt.popup.helper.clickElementByQuerySelectorAll("#picker-identities-list > .menu-item");
+    });
+
+    it("should open the page in a new tab and add an exemption for the initial tab", async function () {
+      // should have created a new tab with the confirm page
+      this.webExt.background.browser.tabs.create.should.have.been.calledWithMatch({
+        active: true,
+        cookieStoreId: "firefox-container-4",
+        index: 1,
+        openerTabId: null,
+        url: "http://example.com"
+      });
+      // should have added the initial tab to the exempted list
+      const siteStoreKey = this.webExt.background.window.assignManager.storageArea.getSiteStoreKey(url);
+      const isExempted = this.webExt.background.window.assignManager.storageArea.isExempted(siteStoreKey, this.initialTabId);
+      isExempted.should.be.true;
+    });
+
+    describe("delete firefox-container-4", function () {
+      beforeEach(async function () {
+        await this.webExt.background.window.assignManager.deleteContainer("4");
+        await nextTick();
+      });
+
+      it("should have removed the initial tab's exemption", function () {
+        const siteStoreKey = this.webExt.background.window.assignManager.storageArea.getSiteStoreKey(url);
+        const isExempted = this.webExt.background.window.assignManager.storageArea.isExempted(siteStoreKey, this.initialTabId);
+        isExempted.should.be.false;
+      });
+    });
+  });
+});


### PR DESCRIPTION
…deleting container

**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

Exempted tab entries for all sites in a container are now removed when the container is deleted.

Includes a unit test to verify this.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* #2910 

