### PR TITLE
Feature: catchall domains - e.g. *.google.com

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -93,6 +93,7 @@ module.exports = defineConfig([{
       "assignManager": true,
       "badge": true,
       "backgroundLogic": true,
+      "domainManager": true,
       "identityState": true,
       "messageHandler": true,
       "sync": true,

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -242,6 +242,7 @@ body {
 [data-theme="dark"] img.clear-storage-icon,
 [data-theme="dark"] img.delete-assignment,
 [data-theme="dark"] #edit-sites-assigned .menu-icon,
+[data-theme="dark"] #edit-domains-assigned .menu-icon,
 [data-theme="dark"] #container-info-table .menu-icon,
 [data-theme="dark"] #always-open .menu-icon,
 [data-theme="dark"] #always-open-in .menu-icon {
@@ -1989,6 +1990,7 @@ h3.title {
 
 /* Maintain 1:1 square ratio for favicons of websites added to a specific container */
 #edit-sites-assigned .menu-icon,
+#edit-domains-assigned .menu-icon,
 #container-info-table .menu-icon {
   inline-size: 16px;
 }

--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -46,6 +46,18 @@ window.assignManager = {
       return this.getByUrlKey(siteStoreKey);
     },
 
+    async match(pageUrl) {
+      const domainMatchKeys = domainManager.getDomainMatchKeys(pageUrl);
+      const siteStoreKey = this.getSiteStoreKey(pageUrl);
+      const storageResponse = await this.area.get([...domainMatchKeys, siteStoreKey]);
+      const domainStoreKey = domainMatchKeys.find(key => key in storageResponse);
+      const site = storageResponse[domainStoreKey ?? siteStoreKey];
+      if (domainStoreKey) {
+        site.isDomain = true;
+      }
+      return [domainStoreKey ?? siteStoreKey, site];
+    },
+
     async getSyncEnabled() {
       const { syncEnabled } = await browser.storage.local.get("syncEnabled");
       return !!syncEnabled;
@@ -118,9 +130,15 @@ window.assignManager = {
             continue;
           }
           const site = siteConfigs[urlKey];
-          // In hindsight we should have stored this
-          // TODO file a follow up to clean the storage onLoad
-          site.hostname = urlKey.replace(/^siteContainerMap@@_/, "");
+          const domainName = domainManager.getDomainNameFromStoreKey(urlKey);
+          if (domainName) {
+            site.hostname = domainName;
+            site.isDomain = true;
+          } else {
+            // In hindsight we should have stored this
+            // TODO file a follow up to clean the storage onLoad
+            site.hostname = urlKey.replace(/^siteContainerMap@@_/, "");
+          }
           sites[urlKey] = site;
         }
       }
@@ -172,11 +190,11 @@ window.assignManager = {
 
       // If we have existing data and for some reason it hasn't been
       // deleted etc lets update it
-      this.storageArea.get(pageUrl).then((siteSettings) => {
+      this.storageArea.match(pageUrl).then(([siteStoreKey, siteSettings]) => {
         if (siteSettings) {
           siteSettings.neverAsk = true;
           siteSettings.userContextId = backgroundLogic.getUserContextIdFromCookieStoreId(m.cookieStoreId);
-          this.storageArea.set(pageUrl, siteSettings);
+          this.storageArea.set(siteStoreKey, siteSettings);
         }
       }).catch((e) => {
         throw e;
@@ -186,8 +204,8 @@ window.assignManager = {
 
   // We return here so the confirm page can load the tab when exempted
   async _exemptTab(m) {
-    const pageUrl = m.pageUrl;
-    await this.storageArea.setExempted(pageUrl, m.tabId);
+    const [siteStoreKey] = await this.storageArea.match(m.pageUrl);
+    await this.storageArea.setExempted(siteStoreKey, m.tabId);
     return true;
   },
 
@@ -224,9 +242,9 @@ window.assignManager = {
       return {};
     }
     this.removeContextMenu();
-    const [tab, siteSettings] = await Promise.all([
+    const [tab, [siteStoreKey, siteSettings]] = await Promise.all([
       browser.tabs.get(options.tabId),
-      this.storageArea.get(options.url)
+      this.storageArea.match(options.url)
     ]);
     let container;
     try {
@@ -238,7 +256,7 @@ window.assignManager = {
 
     // The container we have in the assignment map isn't present any
     // more so lets remove it then continue the existing load
-    if (siteSettings && !container) {
+    if (siteSettings && !siteSettings.isDomain && !container) {
       this.deleteContainer(siteSettings.userContextId);
       return {};
     }
@@ -267,7 +285,7 @@ window.assignManager = {
     if (!siteIsolatedReloadInDefault) {
       if (!siteSettings
           || userContextId === siteSettings.userContextId
-          || this.storageArea.isExempted(options.url, tab.id)) {
+          || this.storageArea.isExempted(siteStoreKey, tab.id)) {
         return {};
       }
     }
@@ -585,6 +603,16 @@ window.assignManager = {
   },
 
   async _setOrRemoveAssignment(tabId, pageUrl, userContextId, remove) {
+    const assignmentStoreKey = this.storageArea.getSiteStoreKey(pageUrl);
+    await this.setOrRemoveAssignmentOrDomain(tabId, assignmentStoreKey, userContextId, remove, false);
+  },
+
+  async _setOrRemoveDomain(domainName, userContextId, remove) {
+    const domainStoreKey = domainManager.getDomainStoreKeyFromName(domainName);
+    await this.setOrRemoveAssignmentOrDomain(false, domainStoreKey, userContextId, remove, true);
+  },
+
+  async setOrRemoveAssignmentOrDomain(tabId, storeKey, userContextId, remove, isDomain) {
     let actionName;
     // https://github.com/mozilla/testpilot-containers/issues/626
     // Context menu has stored context IDs as strings, so we need to coerce
@@ -593,11 +621,17 @@ window.assignManager = {
 
     if (!remove) {
       const tabs = await browser.tabs.query({});
-      const assignmentStoreKey = this.storageArea.getSiteStoreKey(pageUrl);
       const exemptedTabIds = tabs.filter((tab) => {
-        const tabStoreKey = this.storageArea.getSiteStoreKey(tab.url);
+        let isSameHostname;
+        if (isDomain) {
+          const tabDomainMatchKeys = domainManager.getDomainMatchKeys(tab.url);
+          isSameHostname = !!tabDomainMatchKeys.find(key => key === storeKey);
+        } else {
+          const tabStoreKey = this.storageArea.getSiteStoreKey(tab.url);
+          isSameHostname = tabStoreKey === storeKey;
+        }
         /* Auto exempt all tabs that exist for this hostname that are not in the same container */
-        if (tabStoreKey === assignmentStoreKey &&
+        if (isSameHostname &&
             this.getUserContextIdFromCookieStore(tab) !== userContextId) {
           return true;
         }
@@ -606,14 +640,14 @@ window.assignManager = {
         return tab.id;
       });
 
-      await this.storageArea.set(pageUrl, {
+      await this.storageArea.set(storeKey, {
         userContextId,
         neverAsk: false
       }, exemptedTabIds);
       actionName = "assigned site to always open in this container";
     } else {
       // Remove assignment
-      await this.storageArea.remove(pageUrl);
+      await this.storageArea.remove(storeKey);
 
       actionName = "removed from assigned sites list";
 
@@ -651,13 +685,15 @@ window.assignManager = {
     // Ensure we have a cookieStore to assign to
     if (cookieStore
         && this.isTabPermittedAssign(tab)) {
-      return this.storageArea.get(tab.url);
+      const [, siteSettings] = await this.storageArea.match(tab.url);
+      return siteSettings;
     }
     return false;
   },
 
-  _getByContainer(userContextId) {
-    return this.storageArea.getAssignedSites(userContextId);
+  async _getByContainer(userContextId) {
+    const sites = await this.storageArea.getAssignedSites(userContextId);
+    return domainManager.getDomainsAndAssignments(sites);
   },
 
   removeContextMenu() {
@@ -695,6 +731,7 @@ window.assignManager = {
       checked,
       type: "checkbox",
       contexts: ["all"],
+      enabled: !siteSettings?.isDomain
     });
 
     browser.contextMenus.create({

--- a/src/js/background/domainManager.js
+++ b/src/js/background/domainManager.js
@@ -1,0 +1,110 @@
+window.domainManager = {
+  isEnabled() {
+    return "publicSuffix" in browser;
+  },
+
+  getDomainNameFromHostname(hostname) {
+    if (!this.isEnabled()) { return null; }
+    try {
+      const domainName = browser.publicSuffix.getDomain(
+        hostname,
+        { allowUnknownSuffix: true, encoding: "display" },
+      );
+      return domainName?.endsWith(".")
+        ? domainName.slice(0, -1)
+        : domainName;
+    } catch {
+      return null;
+    }
+  },
+
+  getDomainStoreKey(pageUrlorUrlKey) {
+    if (pageUrlorUrlKey.includes("siteContainerMap@@_")) return pageUrlorUrlKey;
+    const url = new window.URL(pageUrlorUrlKey);
+    const domainName = this.getDomainNameFromHostname(url.hostname);
+    return domainName ? this.getDomainStoreKeyFromHostname(domainName) : null;
+  },
+
+  getDomainMatchKeys(pageUrl) {
+    const url = new window.URL(pageUrl);
+    const domainName = this.getDomainNameFromHostname(url.hostname);
+    return domainName ? this.getDomainMatchKeysFromName(domainName) : [];
+  },
+
+  getDomainStoreKeyFromName(domainName) {
+    const storagePrefix = "siteContainerMap@@_*.";
+    return `${storagePrefix}${domainName}`;
+  },
+
+  getDomainMatchKeysFromName(domainName) {
+    // E.g. "mysite.s3.us-west-1.amazonaws.com" ===>
+    // [
+    //   "siteContainerMap@@_*.mysite.s3.us-west-1.amazonaws.com",
+    //   "siteContainerMap@@_*.s3.us-west-1.amazonaws.com",
+    //   "siteContainerMap@@_*.us-west-1.amazonaws.com",
+    //   "siteContainerMap@@_*.amazonaws.com",
+    // ]
+    const labels = domainName.split(".");
+    let suffix = labels.pop();
+    return labels
+      .reverse()
+      .map(label      => suffix = `${label}.${suffix}`)
+      .map(domainName => this.getDomainStoreKeyFromName(domainName))
+      .reverse();
+  },
+
+  getDomainNameFromStoreKey(domainStoreKey) {
+    const storagePrefix = "siteContainerMap@@_*.";
+    if (domainStoreKey.startsWith(storagePrefix)) {
+      return domainStoreKey.slice(storagePrefix.length);
+    }
+    return null;
+  },
+
+  async getDomainsAndAssignments(containerSites) {
+    if (!this.isEnabled()) {
+      return { domains: {}, assignments: containerSites };
+    }
+
+    const enabledDomains = new Set(Object.entries(containerSites)
+      .filter(([, site]) => site.isDomain)
+      .map(([siteStoreKey]) => siteStoreKey)
+    );
+
+    const domains = {};
+    const assignments = {};
+    for (const [siteStoreKey, site] of Object.entries(containerSites)) {
+      // Site is an enabled domain
+      if (site.isDomain) {
+        domains[siteStoreKey] = site;
+        continue;
+      }
+
+      // Site with invalid hostname
+      const domainName = this.getDomainNameFromHostname(site.hostname);
+      if (!domainName) {
+        assignments[siteStoreKey] = site;
+        continue;
+      }
+
+      // Enabled domain exists for site - exclude site
+      if (enabledDomains.size) {
+        const domainMatchKeys = this.getDomainMatchKeysFromName(domainName);
+        if (domainMatchKeys.find(key => enabledDomains.has(key))) {
+          continue;
+        }
+      }
+
+      // No enabled domain for site - add site, and add a disabled domain placeholder,
+      // since these are not stored
+      assignments[siteStoreKey] = site;
+      const domainStoreKey = this.getDomainStoreKeyFromName(domainName);
+      if (!(domainStoreKey in domains)) {
+        const userContextId = site.userContextId;
+        const domainSite = { hostname: domainName, userContextId, isDomain: true, disabled: true };
+        domains[domainStoreKey] = domainSite;
+      }
+    }
+    return { domains, assignments };
+  },
+};

--- a/src/js/background/index.html
+++ b/src/js/background/index.html
@@ -21,6 +21,7 @@
     <script type="text/javascript" src="mozillaVpnBackground.js"></script>
     <script type="text/javascript" src="assignManager.js"></script>
     <script type="text/javascript" src="badge.js"></script>
+    <script type="text/javascript" src="domainManager.js"></script>
     <script type="text/javascript" src="identityState.js"></script>
     <script type="text/javascript" src="messageHandler.js"></script>
     <script type="text/javascript" src="sync.js"></script>

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -48,6 +48,9 @@ const messageHandler = {
         // m.url is the assignment to be removed/added
         response = assignManager._setOrRemoveAssignment(m.tabId, m.url, m.userContextId, m.value);
         break;
+      case "setOrRemoveDomain":
+        response = assignManager._setOrRemoveDomain(m.domain, m.userContextId, m.value);
+        break;
       case "resetCookiesForSite":
         response = assignManager._resetCookiesForSite(m.pageUrl, m.cookieStoreId);
         break;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1433,13 +1433,13 @@ Logic.registerPanel(P_CONTAINER_ASSIGNMENTS, {
     document.getElementById("edit-assignments-title").textContent = identity.name;
 
     const userContextId = Logic.currentUserContextId();
-    const assignments = await Logic.getAssignmentObjectByContainer(userContextId);
-    this.showAssignedContainers(assignments);
+    const { domains, assignments } = await Logic.getAssignmentObjectByContainer(userContextId);
+    this.showAssignedContainers(domains, assignments);
 
     return Promise.resolve(null);
   },
 
-  showAssignedContainers(assignments) {
+  showAssignedContainers(domains, assignments) {
     const closeContEl = document.querySelector("#close-container-assignment-panel");
     Utils.addEnterHandler(closeContEl, () => {
       const identity = Logic.currentIdentity();
@@ -1447,15 +1447,63 @@ Logic.registerPanel(P_CONTAINER_ASSIGNMENTS, {
     });
 
     const assignmentPanel = document.getElementById("edit-sites-assigned");
-    const assignmentKeys = Object.keys(assignments);
-    assignmentPanel.hidden = !(assignmentKeys.length > 0);
-    if (assignments) {
-      const tableElement = document.querySelector("#edit-sites-assigned");
-      /* Remove previous assignment list,
-         after removing one we rerender the list */
-      while (tableElement.firstChild) {
-        tableElement.firstChild.remove();
+    const domainsHeaderElement = document.querySelector("#edit-domains-assigned-header");
+    const assignmentsHeaderElement = document.querySelector("#edit-sites-assigned-header");
+    const domainsTableElement = document.querySelector("#edit-domains-assigned");
+    const assignmentsTableElement = document.querySelector("#edit-sites-assigned");
+    const domainKeys = Object.keys(domains).sort();
+    const assignmentKeys = Object.keys(assignments).sort();
+    assignmentPanel.hidden = !assignmentKeys.length && !domainKeys.length;
+    if (domainKeys.length) {
+      domainsHeaderElement.classList.remove("hide");
+    } else {
+      domainsHeaderElement.classList.add("hide");
+    }
+    if (assignmentKeys.length) {
+      assignmentsHeaderElement.classList.remove("hide");
+    } else {
+      assignmentsHeaderElement.classList.add("hide");
+    }
+    domainsTableElement.replaceChildren();
+    assignmentsTableElement.replaceChildren();
+    domainKeys.forEach((domainKey) => {
+      const domain = domains[domainKey];
+      const domainName = domain.hostname;
+      const trElement = document.createElement("tr");
+      const assumedUrl = `https://${domainName}/favicon.ico`;
+      trElement.innerHTML = Utils.escaped`
+      <td>
+        <div class="favicon"></div>
+        <span title="${domainName}" class="menu-text truncate-text">${domainName}</span>
+        <label class="switch">
+          <input id="domain-enabled" class="switch-input" name="domain-enabled" type="checkbox">
+          <span class="slider round"></span>
+        </label>
+      </td>`;
+      trElement.getElementsByClassName("favicon")[0].appendChild(Utils.createFavIconElement(assumedUrl));
+      const checkboxElement = trElement.querySelector("#domain-enabled");
+      if (domain.disabled) {
+        checkboxElement.removeAttribute("checked");
+      } else {
+        checkboxElement.setAttribute("checked", "checked");
       }
+      checkboxElement.addEventListener("click", (event) => {
+        event.target.setAttribute("disabled", "disabled");
+        setTimeout(async () => {
+          const userContextId = Logic.currentUserContextId();
+          const remove = !domain.disabled;
+          try {
+            await Utils.setOrRemoveDomain(domainName, userContextId, remove);
+          } finally {
+            const { domains, assignments } = await Logic.getAssignmentObjectByContainer(userContextId);
+            this.showAssignedContainers(domains, assignments);
+          }
+        });
+      });
+      trElement.classList.add("menu-item", "hover-highlight", "keyboard-nav");
+      domainsTableElement.appendChild(trElement);
+    });
+    if (assignments) {
       assignmentKeys.forEach((siteKey) => {
         const site = assignments[siteKey];
         const trElement = document.createElement("tr");
@@ -1479,7 +1527,7 @@ Logic.registerPanel(P_CONTAINER_ASSIGNMENTS, {
           // const currentTab = await Utils.currentTab();
           Utils.setOrRemoveAssignment(false, assumedUrl, userContextId, true);
           delete assignments[siteKey];
-          this.showAssignedContainers(assignments);
+          this.showAssignedContainers(domains, assignments);
         });
         const resetButton = trElement.querySelector(".reset-button");
         Utils.addEnterHandler(resetButton, async () => {
@@ -1496,7 +1544,7 @@ Logic.registerPanel(P_CONTAINER_ASSIGNMENTS, {
           }
         });
         trElement.classList.add("menu-item", "hover-highlight", "keyboard-nav");
-        tableElement.appendChild(trElement);
+        assignmentsTableElement.appendChild(trElement);
       });
     }
   },

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -141,6 +141,15 @@ const Utils = {
     });
   },
 
+  setOrRemoveDomain(domain, userContextId, value) {
+    return browser.runtime.sendMessage({
+      method: "setOrRemoveDomain",
+      domain,
+      userContextId,
+      value
+    });
+  },
+
   resetCookiesForSite(pageUrl, cookieStoreId) {
     return browser.runtime.sendMessage({ 
       method: "resetCookiesForSite", 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,6 +18,7 @@
     "history",
     "idle",
     "management",
+    "publicSuffix",
     "storage",
     "unlimitedStorage",
     "tabs",
@@ -33,7 +34,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "@testpilot-containers",
-      "strict_min_version": "91.1.0",
+      "strict_min_version": "115.0.0",
       "data_collection_permissions": {
         "required": ["none"]
       }

--- a/src/popup.html
+++ b/src/popup.html
@@ -388,9 +388,26 @@
     <button class="btn-return arrow-left controller" id="close-container-assignment-panel"></button>
     <hr>
     <div class="scrollable edit-sites-assigned">
-      <div class="sub-header" data-i18n-attribute-message-id="sitesAssignedToThisContainer"></div>
-      <table class="menu scrollable" id="edit-sites-assigned">
-        <tr class="menu-item hover-highlight" tabindex="0">
+      <div class="sub-header-wrapper" id="edit-domains-assigned-header">
+        <div class="sub-header" data-i18n-message-id="enableAllSubdomains"></div>
+      </div>
+      <table class="menu" id="edit-domains-assigned">
+        <tr class="menu-item" tabindex="0">
+          <td>
+            <div class="favicon"><img class="menu-icon" src="https://www.mozilla.org/favicon.ico" /></div>
+            <span class="menu-text truncate-text">www.mozillllllllllllllllllllllllllllla.org</span>
+            <label class="switch">
+              <input id="domain-enabled" class="switch-input" name="domain-enabled" type="checkbox">
+              <span class="slider round"></span>
+            </label>
+          </td>
+        </tr>
+      </table>
+      <div class="sub-header-wrapper" id="edit-sites-assigned-header">
+        <div class="sub-header" data-i18n-message-id="sitesAssignedToThisContainer"></div>
+      </div>
+      <table class="menu" id="edit-sites-assigned">
+        <tr class="menu-item hover-highlight" tabindex="1">
           <td>
             <div class="favicon"><img class="menu-icon" src="https://www.mozilla.org/favicon.ico" /></div>
             <span class="menu-text truncate-text">www.mozillllllllllllllllllllllllllllla.org</span>

--- a/test/common.js
+++ b/test/common.js
@@ -35,6 +35,13 @@ const buildDom = async ({background = {}, popup = {}}) => {
         // Let it return a Promise instead, so that .then() calls chained to
         // it (in src/js/background/assignManager.js) do not fail.
         window.browser.contextMenus.remove.resolves();
+
+        window.browser.publicSuffix = {
+          getDomain: (domain) => {
+            // Just return the last 2 domain labels
+            return domain.split(".").slice(-2).join(".");
+          }
+        };
       }
     }
   };

--- a/test/features/domains.test.js
+++ b/test/features/domains.test.js
@@ -1,0 +1,72 @@
+const {initializeWithTab} = require("../common");
+
+describe("Catchall domains", function () {
+  describe("set banana.example.com to 'Always open in' firefox-container-4", function () {
+    const url1 = "http://banana.example.com";
+    const url2 = "http://avocado.example.com";
+    const domain = "example.com";
+
+    beforeEach(async function () {
+      this.webExt = await initializeWithTab({
+        cookieStoreId: "firefox-container-4",
+        url: url1
+      });
+      await this.webExt.popup.helper.clickElementById("always-open-in");
+      await this.webExt.popup.helper.clickElementByQuerySelectorAll("#picker-identities-list > .menu-item");
+    });
+
+    afterEach(function () {
+      this.webExt.destroy();
+    });
+
+    describe("open avocado.example.com in a new tab in the default container", function () {
+      beforeEach(async function () {
+        await this.webExt.background.browser.tabs._create({
+          cookieStoreId: "firefox-default",
+          url: url2
+        }, {
+          options: {
+            webRequestError: true // because request is canceled due to reopening
+          }
+        });
+      });
+
+      it("should not remove tab #2 or open the confirm page in tab #3", async function () {
+        this.webExt.background.browser.tabs.create.should.not.have.been.called;
+        this.webExt.background.browser.tabs.remove.should.not.have.been.called;
+      });
+    });
+
+    describe("enable *.example.com in firefox-container-4", function () {
+      beforeEach(async function () {
+        await this.webExt.background.window.assignManager._setOrRemoveDomain(domain, "4");
+      });
+
+      describe("open avocado.example.com in a new tab in the default container", function () {
+        beforeEach(async function () {
+          this.newTab = await this.webExt.background.browser.tabs._create({
+            cookieStoreId: "firefox-default",
+            url: url2
+          }, {
+            options: {
+              webRequestError: true // because request is canceled due to reopening
+            }
+          });
+        });
+
+        it("should remove tab #2 and open the confirm page in tab #3", async function () {
+          this.webExt.background.browser.tabs.create.should.have.been.calledWithMatch({
+            url: "moz-extension://fake/confirm-page.html?" +
+                  `url=${encodeURIComponent(url2)}` +
+                  `&cookieStoreId=${this.webExt.tab.cookieStoreId}`,
+            cookieStoreId: undefined,
+            openerTabId: null,
+            index: 2,
+            active: true
+          });
+          this.webExt.background.browser.tabs.remove.should.have.been.calledWith(this.newTab.id);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

Adds the ability to assign all subdomains of a domain to a container.

The list of domains is automatically updated as new sites are assigned to a container. This feature is made possible by the new [`publicSuffix`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/publicSuffix) API that is due to be released in [Firefox 153](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/153).


https://github.com/user-attachments/assets/5e0a9933-5c3d-4fd0-921b-9604f654caf9



## Type of change

*Select all that apply.*

- [ ] Bug fix
- [x] New feature
- [x] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* #473 
* #2352 
