### PR TITLE
Fix #2069

### DIFF
--- a/src/js/background/assignManager.js
+++ b/src/js/background/assignManager.js
@@ -272,7 +272,7 @@ window.assignManager = {
       }
     }
     const replaceTabEnabled = await this.storageArea.getReplaceTabEnabled();
-    const removeTab = backgroundLogic.NEW_TAB_PAGES.has(tab.url)
+    const removeTab = await backgroundLogic.isNewTabPage(tab.url)
       || (messageHandler.lastCreatedTab
         && messageHandler.lastCreatedTab.id === tab.id)
       || replaceTabEnabled;

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -82,6 +82,28 @@ const backgroundLogic = {
     }
   },
 
+  /**
+   * Returns true if url is a page the user would not miss if it were
+   * replaced/closed: a built-in "new tab" page, or the page currently
+   * shown by the browser's homepage or new-tab-page setting (which may be
+   * overridden by another extension, e.g. a "new tab" replacement).
+   */
+  async isNewTabPage(url) {
+    if (this.NEW_TAB_PAGES.has(url)) {
+      return true;
+    }
+    try {
+      const [homepage, newTabPage] = await Promise.all([
+        browser.browserSettings.homepageOverride.get({}),
+        browser.browserSettings.newTabPageOverride.get({})
+      ]);
+      const homepageUrls = homepage && homepage.value ? homepage.value.split("|") : [];
+      return homepageUrls.includes(url) || !!(newTabPage && newTabPage.value === url);
+    } catch {
+      return false;
+    }
+  },
+
   async reopenInContainer(cookieStoreId) {
     const currentTab = await browser.tabs.query({ active: true, currentWindow: true });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,6 +12,7 @@
   "permissions": [
     "<all_urls>",
     "activeTab",
+    "browserSettings",
     "cookies",
     "contextMenus",
     "contextualIdentities",

--- a/test/issues/2069.test.js
+++ b/test/issues/2069.test.js
@@ -1,0 +1,67 @@
+const {expect, initializeWithTab} = require("../common");
+
+// https://github.com/mozilla/multi-account-containers/issues/2069
+describe("#2069", function () {
+  const assignedUrl = "https://amazon.com/";
+
+  const assign = async (webExt) => {
+    await webExt.background.window.assignManager.storageArea.set(assignedUrl, {
+      userContextId: "4",
+      neverAsk: true
+    }, []);
+    // create and drop an unrelated tab so messageHandler's "just created
+    // this tab" grace period no longer refers to our tab under test - only
+    // the homepage/new-tab-page detection should cause it to be replaced
+    await webExt.background.browser.tabs._create({url: "about:blank"});
+  };
+
+  describe("when the current tab shows the browser's homepage", function () {
+    const homepageUrl = "https://google.com/";
+
+    beforeEach(async function () {
+      this.webExt = await initializeWithTab({
+        cookieStoreId: "firefox-default",
+        url: homepageUrl
+      });
+      this.webExt.background.browser.browserSettings.homepageOverride.get
+        .resolves({value: homepageUrl, levelOfControl: "controlled_by_this_extension"});
+
+      await assign(this.webExt);
+
+      await this.webExt.background.browser.tabs._navigate(this.webExt.tab.id, assignedUrl);
+    });
+
+    afterEach(function () {
+      this.webExt.destroy();
+    });
+
+    it("should replace the homepage tab instead of opening a second tab", function () {
+      expect(this.webExt.background.browser.tabs.remove).to.have.been.calledWith(this.webExt.tab.id);
+    });
+  });
+
+  describe("when the current tab shows a custom new-tab page from another extension", function () {
+    const newTabUrl = "moz-extension://other-addon/newtab.html";
+
+    beforeEach(async function () {
+      this.webExt = await initializeWithTab({
+        cookieStoreId: "firefox-default",
+        url: newTabUrl
+      });
+      this.webExt.background.browser.browserSettings.newTabPageOverride.get
+        .resolves({value: newTabUrl, levelOfControl: "controlled_by_other_extensions"});
+
+      await assign(this.webExt);
+
+      await this.webExt.background.browser.tabs._navigate(this.webExt.tab.id, assignedUrl);
+    });
+
+    afterEach(function () {
+      this.webExt.destroy();
+    });
+
+    it("should replace the custom new-tab page instead of opening a second tab", function () {
+      expect(this.webExt.background.browser.tabs.remove).to.have.been.calledWith(this.webExt.tab.id);
+    });
+  });
+});


### PR DESCRIPTION

**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [x] I added test coverages if relevant.

# Description

Fix the behaviour of https://github.com/mozilla/multi-account-containers/issues/2069
Custom new tabs/home urls will now close when a clicked link is opened in a container.

*AI-notice*

I fully created this change with Claude.  
And I have reviewed the code but Javascript is not the area of expertise.
Also I have tested the code with a new profile in an actual FF browser (152.0.4). 
I have fully included me -a human- in the loop.

As far as I could find there is no AI policy.
If this is not allowed or appreciated  feel free to close this PR, and my apologies. 

## Type of change

*Select all that apply.*

- [x] Bug fix
- [ ] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* https://github.com/mozilla/multi-account-containers/issues/2069
