### PR TITLE
Add option to keep containers sorted alphabetically

### DIFF
--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -54,6 +54,10 @@ const backgroundLogic = {
       this._removeSurveyAchievement();
     });
     browser.runtime.onStartup.addListener(this.updateTranslationInManifest);
+
+    browser.contextualIdentities.onCreated.addListener(() => this.sortContainersAlphabetically());
+    browser.contextualIdentities.onUpdated.addListener(() => this.sortContainersAlphabetically());
+    this.sortContainersAlphabetically();
   },
 
   /**
@@ -410,6 +414,24 @@ const backgroundLogic = {
     });
     await Promise.all(identitiesPromise);
     return identitiesOutput;
+  },
+
+  async sortContainersAlphabetically() {
+    // Reordering containers requires contextualIdentities.move (Firefox 141+).
+    if (typeof browser.contextualIdentities.move !== "function") {
+      return;
+    }
+    const { alphabeticalSortEnabled } = await browser.storage.local.get("alphabeticalSortEnabled");
+    if (!alphabeticalSortEnabled) {
+      return;
+    }
+    const identities = await browser.contextualIdentities.query({});
+    const sorted = identities.slice().sort((a, b) => a.name.localeCompare(b.name));
+    // Skipping when already sorted also stops any onUpdated retrigger from move().
+    if (sorted.every((identity, index) => identity === identities[index])) {
+      return;
+    }
+    await browser.contextualIdentities.move(sorted.map((identity) => identity.cookieStoreId), 0);
   },
 
   async sortTabs() {

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -417,7 +417,8 @@ const backgroundLogic = {
   },
 
   async sortContainersAlphabetically() {
-    // Reordering containers requires contextualIdentities.move (Firefox 141+).
+    // Reordering containers requires contextualIdentities.move, which older
+    // Firefox versions do not have.
     if (typeof browser.contextualIdentities.move !== "function") {
       return;
     }
@@ -431,7 +432,12 @@ const backgroundLogic = {
     if (sorted.every((identity, index) => identity === identities[index])) {
       return;
     }
-    await browser.contextualIdentities.move(sorted.map((identity) => identity.cookieStoreId), 0);
+    // move() keeps the identities' current relative order regardless of the
+    // order of the ids passed to it, so one call with the full sorted list
+    // cannot permute. Place one container at a time instead.
+    for (const [index, identity] of sorted.entries()) {
+      await browser.contextualIdentities.move(identity.cookieStoreId, index);
+    }
   },
 
   async sortTabs() {

--- a/src/js/background/messageHandler.js
+++ b/src/js/background/messageHandler.js
@@ -54,6 +54,9 @@ const messageHandler = {
       case "sortTabs":
         backgroundLogic.sortTabs();
         break;
+      case "sortContainersAlphabetically":
+        backgroundLogic.sortContainersAlphabetically();
+        break;
       case "showTabs":
         backgroundLogic.unhideContainer(m.cookieStoreId);
         break;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -48,6 +48,14 @@ async function enableDisableSync() {
   browser.runtime.sendMessage({ method: "resetSync" });
 }
 
+async function enableDisableAlphabeticalSort() {
+  const checkbox = document.querySelector("#alphabeticalSortCheck");
+  await browser.storage.local.set({alphabeticalSortEnabled: !!checkbox.checked});
+  if (checkbox.checked) {
+    browser.runtime.sendMessage({ method: "sortContainersAlphabetically" });
+  }
+}
+
 async function enableDisableReplaceTab() {
   const checkbox = document.querySelector("#replaceTabCheck");
   await browser.storage.local.set({replaceTabEnabled: !!checkbox.checked});
@@ -62,10 +70,12 @@ async function changeTheme(event) {
 async function setupOptions() {
   const { syncEnabled } = await browser.storage.local.get("syncEnabled");
   const { replaceTabEnabled } = await browser.storage.local.get("replaceTabEnabled");
+  const { alphabeticalSortEnabled } = await browser.storage.local.get("alphabeticalSortEnabled");
   const { currentThemeId } = await browser.storage.local.get("currentThemeId");
 
   document.querySelector("#syncCheck").checked = !!syncEnabled;
   document.querySelector("#replaceTabCheck").checked = !!replaceTabEnabled;
+  document.querySelector("#alphabeticalSortCheck").checked = !!alphabeticalSortEnabled;
   document.querySelector("#changeTheme").selectedIndex = currentThemeId;
   setupContainerShortcutSelects();
 }
@@ -123,6 +133,7 @@ browser.permissions.onRemoved.addListener(resetPermissionsUi);
 document.addEventListener("DOMContentLoaded", setupOptions);
 document.querySelector("#syncCheck").addEventListener( "change", enableDisableSync);
 document.querySelector("#replaceTabCheck").addEventListener( "change", enableDisableReplaceTab);
+document.querySelector("#alphabeticalSortCheck").addEventListener( "change", enableDisableAlphabeticalSort);
 document.querySelector("#changeTheme").addEventListener( "change", changeTheme);
 
 maybeShowPermissionsWarningIcon();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -255,10 +255,12 @@ const Logic = {
           windowId: browser.windows.WINDOW_ID_CURRENT
         }
       }),
-      browser.storage.local.get([CONTAINER_ORDER_STORAGE_KEY])
+      browser.storage.local.get([CONTAINER_ORDER_STORAGE_KEY, "alphabeticalSortEnabled"])
     ]);
     const containerOrder =
       containerOrderStorage && containerOrderStorage[CONTAINER_ORDER_STORAGE_KEY];
+    this._sortAlphabetically =
+      !!(containerOrderStorage && containerOrderStorage.alphabeticalSortEnabled);
     this._identities = identities.map((identity) => {
       const stateObject = state[identity.cookieStoreId];
       if (stateObject) {
@@ -272,7 +274,12 @@ const Logic = {
         identity.order = containerOrder[identity.cookieStoreId];
       }
       return identity;
-    }).sort((i1, i2) => i1.order - i2.order);
+    }).sort((i1, i2) => {
+      if (this._sortAlphabetically) {
+        return i1.name.localeCompare(i2.name);
+      }
+      return i1.order - i2.order;
+    });
   },
 
   getPanelSelector(panel) {
@@ -1209,7 +1216,10 @@ Logic.registerPanel(MANAGE_CONTAINERS_PICKER, {
 
       tr.appendChild(td);
 
-      tr.draggable = true;
+      tr.draggable = !Logic._sortAlphabetically;
+      if (Logic._sortAlphabetically) {
+        td.querySelector(".move-button").remove();
+      }
       tr.dataset.containerId = identity.cookieStoreId;
       tr.addEventListener("dragstart", (e) => {
         e.dataTransfer.setData(CONTAINER_DRAG_DATA_TYPE, identity.cookieStoreId);

--- a/src/options.html
+++ b/src/options.html
@@ -49,6 +49,16 @@
         <p><em data-i18n-message-id="enableSyncDescription"></em></p>
       </div>
 
+      <h3 data-i18n-message-id="containerList"></h3>
+
+      <div class="settings-group">
+        <label>
+          <input type="checkbox" id="alphabeticalSortCheck">
+          <span class="bold" data-i18n-message-id="alphabeticalSort"></span>
+        </label>
+        <p><em data-i18n-message-id="alphabeticalSortDescription"></em></p>
+      </div>
+
       <h3 data-i18n-message-id="tabBehavior"></h3>
 
       <div class="settings-group">


### PR DESCRIPTION
**Before submitting your pull request**

- [x] I agree to license my code under the [MPL 2.0 license](https://www.mozilla.org/en-US/MPL/2.0/).
- [x] I rebased my work on top of the main branch.
- [x] I ran `npm test` and all tests passed.
- [ ] I added test coverages if relevant.

# Description

Adds a "Sort containers alphabetically" checkbox to the options page (off by default).

When enabled:

- the popup renders all container lists sorted by name
- manual drag reordering in the popup is disabled, since the two would conflict
- the browser-level container order is kept sorted via `contextualIdentities.move` on container create and rename and on startup, so the new-tab context menu and about:preferences#containers follow the same order (feature-detected; older Firefox versions just get the popup sort)

Motivation: containers come back in effectively random order after a sync, because sync recreates them in arbitrary key order and the container-order map is local and keyed by machine-specific cookieStoreIds. Deriving the order from names sidesteps that entirely: names sync, so every device converges on the same order with no new synced state.

Implementation note: `contextualIdentities.move` keeps the identities' current relative order regardless of the order of the ids passed in, so the background sorts by moving one container at a time to its target index, the same pattern the existing drag reorder uses.

The three new strings are in a companion PR on the l10n repo: <link>.

Tested on Firefox 153 with ~50 containers: popup, new-tab context menu and about:preferences#containers all sort; new and renamed containers are placed automatically; toggling off restores manual ordering.

## Type of change

*Select all that apply.*

- [ ] Bug fix
- [x] New feature
- [ ] Major change (fix or feature that would cause existing functionality to work differently than in the current version)

Tag issues related to this pull request:

* Closes #1866
* #1625
* #2406
